### PR TITLE
Phase 2: extract Arango.API macro, convert 14 modules

### DIFF
--- a/lib/arango/administration.ex
+++ b/lib/arango/administration.ex
@@ -1,8 +1,7 @@
 defmodule Arango.Administration do
   @moduledoc "ArangoDB Administration methods"
 
-  alias Arango.Request
-  alias Arango.Utils
+  use Arango.API, endpoint: :administration
 
   @doc """
   Return the required version of the database
@@ -11,11 +10,7 @@ defmodule Arango.Administration do
   """
   @spec database_version() :: Arango.ok_error(map)
   def database_version() do
-    %Request{
-      endpoint: :administration,
-      http_method: :get,
-      path: "/_admin/database/target-version"
-    }
+    request(method: :get, path: "/_admin/database/target-version")
   end
 
   @doc """
@@ -28,13 +23,12 @@ defmodule Arango.Administration do
     headers = Utils.opts_to_headers(header_opts, [:*])
     query = Utils.opts_to_query(query_opts, [:*])
 
-    %Request{
-      endpoint: :administration,
-      http_method: :get,
+    request(
+      method: :get,
       headers: headers,
       path: "/_admin/echo",
       query: query
-    }
+    )
   end
 
   @doc """
@@ -46,12 +40,11 @@ defmodule Arango.Administration do
   def log(opts \\ []) do
     query = Utils.opts_to_query(opts, [:upto, :level, :start, :size, :offset, :search, :sort])
 
-    %Request{
-      endpoint: :administration,
-      http_method: :get,
+    request(
+      method: :get,
       path: "/_admin/log",
-      query: query,
-    }
+      query: query
+    )
   end
 
   @doc """
@@ -64,13 +57,12 @@ defmodule Arango.Administration do
     headers = Utils.opts_to_headers(header_opts, [:*])
     query = Utils.opts_to_query(query_opts, [:*])
 
-    %Request{
-      endpoint: :administration,
-      http_method: :get,
+    request(
+      method: :get,
       headers: headers,
       path: "/_admin/long_echo",
-      query: query,
-    }
+      query: query
+    )
   end
 
   @doc """
@@ -81,11 +73,7 @@ defmodule Arango.Administration do
   @deprecated "Removed in API v1/4.0; routing handled internally."
   @spec reload_routing() :: Arango.ok_error(map)
   def reload_routing() do
-    %Request{
-      endpoint: :administration,
-      http_method: :post,
-      path: "/_admin/routing/reload"
-    }
+    request(method: :post, path: "/_admin/routing/reload")
   end
 
   @doc """
@@ -95,11 +83,7 @@ defmodule Arango.Administration do
   """
   @spec server_id() :: Arango.ok_error(map)
   def server_id() do
-    %Request{
-      endpoint: :administration,
-      http_method: :get,
-      path: "/_admin/server/id"
-    }
+    request(method: :get, path: "/_admin/server/id")
   end
 
   @doc """
@@ -109,11 +93,7 @@ defmodule Arango.Administration do
   """
   @spec server_role() :: Arango.ok_error(map)
   def server_role() do
-    %Request{
-      endpoint: :administration,
-      http_method: :get,
-      path: "/_admin/server/role"
-    }
+    request(method: :get, path: "/_admin/server/role")
   end
 
   @doc """
@@ -123,11 +103,7 @@ defmodule Arango.Administration do
   """
   @spec shutdown() :: Arango.ok_error(map)
   def shutdown() do
-    %Request{
-      endpoint: :administration,
-      http_method: :delete,
-      path: "/_admin/shutdown"
-    }
+    request(method: :delete, path: "/_admin/shutdown")
   end
 
   @doc """
@@ -139,12 +115,11 @@ defmodule Arango.Administration do
   def sleep(opts \\ []) do
     query = Utils.opts_to_query(opts, [:duration])
 
-    %Request{
-      endpoint: :administration,
-      http_method: :get,
+    request(
+      method: :get,
       path: "/_admin/sleep",
-      query: query,
-    }
+      query: query
+    )
   end
 
   @doc """
@@ -155,11 +130,7 @@ defmodule Arango.Administration do
   @deprecated "Removed in API v1/4.0. Use Administration.metrics/0 (Prometheus format) when added in Phase 4."
   @spec statistics() :: Arango.ok_error(map)
   def statistics() do
-    %Request{
-      endpoint: :administration,
-      http_method: :get,
-      path: "/_admin/statistics"
-    }
+    request(method: :get, path: "/_admin/statistics")
   end
 
   @doc """
@@ -170,11 +141,7 @@ defmodule Arango.Administration do
   @deprecated "Removed in API v1/4.0. Use Administration.metrics/0 (Prometheus format) when added in Phase 4."
   @spec statistics_description() :: Arango.ok_error(map)
   def statistics_description() do
-    %Request{
-      endpoint: :administration,
-      http_method: :get,
-      path: "/_admin/statistics-description"
-    }
+    request(method: :get, path: "/_admin/statistics-description")
   end
 
   @doc """
@@ -184,11 +151,7 @@ defmodule Arango.Administration do
   """
   @spec test() :: Arango.ok_error(map)
   def test() do
-    %Request{
-      endpoint: :administration,
-      http_method: :post,
-      path: "/_admin/test"
-    }
+    request(method: :post, path: "/_admin/test")
   end
 
   @doc """
@@ -198,11 +161,7 @@ defmodule Arango.Administration do
   """
   @spec time() :: Arango.ok_error(map)
   def time() do
-    %Request{
-      endpoint: :administration,
-      http_method: :get,
-      path: "/_admin/time"
-    }
+    request(method: :get, path: "/_admin/time")
   end
 
   @doc """
@@ -212,12 +171,11 @@ defmodule Arango.Administration do
   """
   @spec endpoints() :: Arango.ok_error(map)
   def endpoints() do
-    %Request{
-      endpoint: :administration,
+    request(
+      method: :get,
       system_only: true,           # or just /_api? Same thing?
-      http_method: :get,
       path: "endpoint"
-    }
+    )
   end
 
   @doc """
@@ -227,11 +185,10 @@ defmodule Arango.Administration do
   """
   @spec version() :: Arango.ok_error(map)
   def version() do
-    %Request{
-      endpoint: :administration,
+    request(
+      method: :get,
       system_only: true,           # or just /_api? Same thing?
-      http_method: :get,
       path: "version"
-    }
+    )
   end
 end

--- a/lib/arango/api.ex
+++ b/lib/arango/api.ex
@@ -1,0 +1,50 @@
+defmodule Arango.API do
+  @moduledoc """
+  Compile-time helpers for API modules.
+
+  ## Usage
+
+      defmodule Arango.Collection do
+        use Arango.API, endpoint: :collection
+
+        def collections do
+          request(method: :get, path: "collection")
+        end
+      end
+
+  `use Arango.API, endpoint: :foo` pins `@endpoint` for the module and imports
+  the `request/1` macro. `request/1` builds an `Arango.Request` struct with
+  `endpoint` pre-filled from `@endpoint`. Pass any other struct field as a
+  keyword (`:method` is rewritten to `:http_method`).
+  """
+
+  defmacro __using__(opts) do
+    endpoint = Keyword.fetch!(opts, :endpoint)
+
+    quote do
+      @endpoint unquote(endpoint)
+      alias Arango.Request
+      alias Arango.Utils
+      import Arango.API, only: [request: 1]
+    end
+  end
+
+  @doc """
+  Build an `%Arango.Request{}` with the module's `@endpoint` pre-filled.
+
+  Accepts any `Arango.Request` field. Use `:method` as shorthand for
+  `:http_method`.
+  """
+  defmacro request(opts) do
+    quote do
+      Arango.API.__build__(@endpoint, unquote(opts))
+    end
+  end
+
+  @doc false
+  def __build__(endpoint, opts) do
+    {method, opts} = Keyword.pop(opts, :method)
+    fields = [endpoint: endpoint] ++ if(method, do: [http_method: method], else: []) ++ opts
+    struct(Arango.Request, fields)
+  end
+end

--- a/lib/arango/aql.ex
+++ b/lib/arango/aql.ex
@@ -9,7 +9,7 @@
 defmodule Arango.Aql do
   @moduledoc "ArangoDB AQL methods"
 
-  alias Arango.Request
+  use Arango.API, endpoint: :aql
 
   @aql_function_deprecation "AQL user functions are removed in API v1/4.0. Inline the logic into your AQL queries."
 
@@ -89,12 +89,11 @@ defmodule Arango.Aql do
   @deprecated @aql_function_deprecation
   @spec functions() :: Arango.ok_error(map)
   def functions() do
-    %Request{
-      endpoint: :aql,
+    request(
       system_only: true,   # or just /_api? Same thing?
-      http_method: :get,
+      method: :get,
       path: "aqlfunction"
-    }
+    )
   end
 
   # @doc """
@@ -105,13 +104,12 @@ defmodule Arango.Aql do
   @deprecated @aql_function_deprecation
   @spec create_function(Function.t) :: Arango.ok_error(map)
   def create_function(function) do
-    %Request{
-      endpoint: :aql,
+    request(
       system_only: true,   # or just /_api? Same thing?
-      http_method: :post,
+      method: :post,
       path: "aqlfunction",
-      body: function,
-    }
+      body: function
+    )
   end
 
   @doc """
@@ -122,12 +120,11 @@ defmodule Arango.Aql do
   @deprecated @aql_function_deprecation
   @spec delete_function(String.t) :: Arango.ok_error(map)
   def delete_function(name) do
-    %Request{
-      endpoint: :aql,
+    request(
       system_only: true,   # or just /_api? Same thing?
-      http_method: :delete,
-      path: "aqlfunction/#{name}",
-    }
+      method: :delete,
+      path: "aqlfunction/#{name}"
+    )
   end
 
   # @doc """
@@ -154,12 +151,11 @@ defmodule Arango.Aql do
       %{query: query}
       |> Map.merge(if Enum.any?(opts), do: %{"options" => opts}, else: %{})
 
-    %Request{
-      endpoint: :aql,
-      http_method: :post,
+    request(
+      method: :post,
       path: "explain",
-      body: explain_request,
-    }
+      body: explain_request
+    )
   end
 
   # @doc """
@@ -169,12 +165,11 @@ defmodule Arango.Aql do
   # """
   @spec validate_query(String.t) :: Arango.ok_error(map)
   def validate_query(query) do
-    %Request{
-      endpoint: :aql,
-      http_method: :post,
+    request(
+      method: :post,
       path: "query",
-      body: %{query: query},
-    }
+      body: %{query: query}
+    )
   end
 
   # @doc """
@@ -184,11 +179,10 @@ defmodule Arango.Aql do
   # """
   @spec clear_query_cache() :: Arango.ok_error(map)
   def clear_query_cache() do
-    %Request{
-      endpoint: :aql,
-      http_method: :delete,
-      path: "query-cache",
-    }
+    request(
+      method: :delete,
+      path: "query-cache"
+    )
   end
 
   # @doc """
@@ -198,11 +192,10 @@ defmodule Arango.Aql do
   # """
   @spec query_cache_properties() :: Arango.ok_error(map)
   def query_cache_properties() do
-    %Request{
-      endpoint: :aql,
-      http_method: :get,
-      path: "query-cache/properties",
-    }
+    request(
+      method: :get,
+      path: "query-cache/properties"
+    )
   end
 
   # @doc """
@@ -222,12 +215,11 @@ defmodule Arango.Aql do
       |> Map.merge(if max_results, do: %{"maxResults" => max_results}, else: %{})
       |> Map.merge(if mode, do: %{"mode" => mode}, else: %{})
 
-    %Request{
-      endpoint: :aql,
-      http_method: :put,
+    request(
+      method: :put,
       path: "query-cache/properties",
-      body: opts,
-    }
+      body: opts
+    )
   end
 
   # @doc """
@@ -237,11 +229,10 @@ defmodule Arango.Aql do
   # """
   @spec current_queries() :: Arango.ok_error(map)
   def current_queries() do
-    %Request{
-      endpoint: :aql,
-      http_method: :get,
-      path: "query/current",
-    }
+    request(
+      method: :get,
+      path: "query/current"
+    )
   end
 
   # @doc """
@@ -251,11 +242,10 @@ defmodule Arango.Aql do
   # """
   @spec query_properties() :: Arango.ok_error(map)
   def query_properties() do
-    %Request{
-      endpoint: :aql,
-      http_method: :get,
-      path: "query/properties",
-    }
+    request(
+      method: :get,
+      path: "query/properties"
+    )
   end
 
   # @doc """
@@ -281,12 +271,11 @@ defmodule Arango.Aql do
       |> Map.merge(if track_slow_queries, do: %{"trackSlowqueries" => track_slow_queries}, else: %{})
       |> Map.merge(if max_query_string_length, do: %{"maxQuerystringlength" => max_query_string_length}, else: %{})
 
-    %Request{
-      endpoint: :aql,
-      http_method: :put,
+    request(
+      method: :put,
       path: "query/properties",
-      body: opts,
-    }
+      body: opts
+    )
   end
 
   # @doc """
@@ -296,11 +285,10 @@ defmodule Arango.Aql do
   # """
   @spec clear_slow_queries() :: Arango.ok_error(map)
   def clear_slow_queries() do
-    %Request{
-      endpoint: :aql,
-      http_method: :delete,
-      path: "query/slow",
-    }
+    request(
+      method: :delete,
+      path: "query/slow"
+    )
   end
 
   # @doc """
@@ -310,11 +298,10 @@ defmodule Arango.Aql do
   # """
   @spec slow_queries() :: Arango.ok_error(map)
   def slow_queries() do
-    %Request{
-      endpoint: :aql,
-      http_method: :get,
-      path: "query/slow",
-    }
+    request(
+      method: :get,
+      path: "query/slow"
+    )
   end
 
   # @doc """
@@ -324,10 +311,9 @@ defmodule Arango.Aql do
   # """
   @spec kill_query(String.t) :: Arango.ok_error(map)
   def kill_query(query_id) do
-    %Request{
-      endpoint: :aql,
-      http_method: :delete,
-      path: "query/#{query_id}",
-    }
+    request(
+      method: :delete,
+      path: "query/#{query_id}"
+    )
   end
 end

--- a/lib/arango/collection.ex
+++ b/lib/arango/collection.ex
@@ -1,8 +1,7 @@
 defmodule Arango.Collection do
   @moduledoc "ArangoDB Collection methods"
 
-  alias Arango.Request
-  alias Arango.Utils
+  use Arango.API, endpoint: :collection
 
   defstruct [
     id: nil,
@@ -49,12 +48,7 @@ defmodule Arango.Collection do
   """
   @spec collections() :: Arango.ok_error(t)
   def collections() do
-    %Request{
-      endpoint: :collection,
-      http_method: :get,
-      path: "collection",
-      ok_decoder: __MODULE__.CollectionDecoder,
-    }
+    request(method: :get, path: "collection", ok_decoder: __MODULE__.CollectionDecoder)
   end
 
   @doc """
@@ -65,13 +59,7 @@ defmodule Arango.Collection do
   @spec create(t | String.t) :: Arango.ok_error(t)
   def create(name) when is_binary(name), do: create(%__MODULE__{name: name})
   def create(collection) do
-    %Request{
-      endpoint: :collection,
-      http_method: :post,
-      path: "collection",
-      body: collection,
-      ok_decoder: __MODULE__.CollectionDecoder,
-    }
+    request(method: :post, path: "collection", body: collection, ok_decoder: __MODULE__.CollectionDecoder)
   end
 
   @doc """
@@ -81,11 +69,7 @@ defmodule Arango.Collection do
   """
   @spec drop(t) :: Arango.ok_error(map)
   def drop(collection) do
-    %Request{
-      endpoint: :collection,
-      http_method: :delete,
-      path: "collection/#{collection.name}",
-    }
+    request(method: :delete, path: "collection/#{collection.name}")
   end
 
   @doc """
@@ -95,12 +79,7 @@ defmodule Arango.Collection do
   """
   @spec collection(t) :: Arango.ok_error(t)
   def collection(collection) do
-    %Request{
-      endpoint: :collection,
-      http_method: :get,
-      path: "collection/#{collection.name}",
-      ok_decoder: __MODULE__.CollectionDecoder,
-    }
+    request(method: :get, path: "collection/#{collection.name}", ok_decoder: __MODULE__.CollectionDecoder)
   end
 
   @doc """
@@ -111,12 +90,7 @@ defmodule Arango.Collection do
   @deprecated "No-op on RocksDB. Removed in API v1/4.0."
   @spec load(t) :: Arango.ok_error(map)
   def load(collection, count \\ true) do
-    %Request{
-      endpoint: :collection,
-      http_method: :put,
-      path: "collection/#{collection.name}/load",
-      body: %{count: count},
-    }
+    request(method: :put, path: "collection/#{collection.name}/load", body: %{count: count})
   end
 
   @doc """
@@ -127,11 +101,7 @@ defmodule Arango.Collection do
   @deprecated "No-op on RocksDB. Removed in API v1/4.0."
   @spec unload(t) :: Arango.ok_error(map)
   def unload(collection) do
-    %Request{
-      endpoint: :collection,
-      http_method: :put,
-      path: "collection/#{collection.name}/unload",
-    }
+    request(method: :put, path: "collection/#{collection.name}/unload")
   end
 
   @doc """
@@ -141,11 +111,7 @@ defmodule Arango.Collection do
   """
   @spec checksum(t) :: Arango.ok_error(map)
   def checksum(collection) do
-    %Request{
-      endpoint: :collection,
-      http_method: :get,
-      path: "collection/#{collection.name}/checksum",
-    }
+    request(method: :get, path: "collection/#{collection.name}/checksum")
   end
 
   @doc """
@@ -155,11 +121,7 @@ defmodule Arango.Collection do
   """
   @spec count(t) :: Arango.ok_error(map)
   def count(collection) do
-    %Request{
-      endpoint: :collection,
-      http_method: :get,
-      path: "collection/#{collection.name}/count",
-    }
+    request(method: :get, path: "collection/#{collection.name}/count")
   end
 
   @doc """
@@ -169,11 +131,7 @@ defmodule Arango.Collection do
   """
   @spec figures(t) :: Arango.ok_error(map)
   def figures(collection) do
-    %Request{
-      endpoint: :collection,
-      http_method: :get,
-      path: "collection/#{collection.name}/figures",
-    }
+    request(method: :get, path: "collection/#{collection.name}/figures")
   end
 
   @doc """
@@ -183,11 +141,7 @@ defmodule Arango.Collection do
   """
   @spec properties(t) :: Arango.ok_error(map)
   def properties(collection) do
-    %Request{
-      endpoint: :collection,
-      http_method: :get,
-      path: "collection/#{collection.name}/properties",
-    }
+    request(method: :get, path: "collection/#{collection.name}/properties")
   end
 
   @doc """
@@ -199,12 +153,11 @@ defmodule Arango.Collection do
   def set_properties(collection, opts \\ []) do
     properties = Utils.opts_to_vars(opts, [:waitForSync, :journalSize])
 
-    %Request{
-      endpoint: :collection,
-      http_method: :put,
+    request(
+      method: :put,
       path: "collection/#{collection.name}/properties",
-      body: properties,
-    }
+      body: properties
+    )
   end
 
   @doc """
@@ -214,12 +167,7 @@ defmodule Arango.Collection do
   """
   @spec rename(t, String.t) :: Arango.ok_error(map)
   def rename(collection, new_name) do
-    %Request{
-      endpoint: :collection,
-      http_method: :put,
-      path: "collection/#{collection.name}/rename",
-      body: %{name: new_name},
-    }
+    request(method: :put, path: "collection/#{collection.name}/rename", body: %{name: new_name})
   end
 
   @doc """
@@ -229,11 +177,7 @@ defmodule Arango.Collection do
   """
   @spec revision(t) :: Arango.ok_error(map)
   def revision(collection) do
-    %Request{
-      endpoint: :collection,
-      http_method: :get,
-      path: "collection/#{collection.name}/revision",
-    }
+    request(method: :get, path: "collection/#{collection.name}/revision")
   end
 
   @doc """
@@ -243,11 +187,7 @@ defmodule Arango.Collection do
   """
   @spec rotate(t) :: Arango.ok_error(map)
   def rotate(collection) do
-    %Request{
-      endpoint: :collection,
-      http_method: :put,
-      path: "collection/#{collection.name}/rotate",
-    }
+    request(method: :put, path: "collection/#{collection.name}/rotate")
   end
 
   @doc """
@@ -257,11 +197,7 @@ defmodule Arango.Collection do
   """
   @spec truncate(t) :: Arango.ok_error(map)
   def truncate(collection) do
-    %Request{
-      endpoint: :collection,
-      http_method: :put,
-      path: "collection/#{collection.name}/truncate",
-    }
+    request(method: :put, path: "collection/#{collection.name}/truncate")
   end
 
   defmodule CollectionDecoder do

--- a/lib/arango/cursor.ex
+++ b/lib/arango/cursor.ex
@@ -1,7 +1,7 @@
 defmodule Arango.Cursor do
   @moduledoc "ArangoDB Cursor methods"
 
-  alias Arango.Request
+  use Arango.API, endpoint: :cursor
 
   defmodule Cursor do
     @moduledoc false
@@ -138,12 +138,11 @@ defmodule Arango.Cursor do
       top_level
       |> Map.merge(if Enum.any?(options), do: %{"options" => options}, else: %{})
 
-    %Request{
-      endpoint: :cursor,
-      http_method: :post,
+    request(
+      method: :post,
       path: "cursor",
       body: cursor_request
-    }
+    )
   end
 
   # @doc """
@@ -153,11 +152,10 @@ defmodule Arango.Cursor do
   # """
   @spec cursor_delete(Cursor.t) :: Arango.ok_error(map)
   def cursor_delete(cursor_id) do
-    %Request{
-      endpoint: :cursor,
-      http_method: :delete,
+    request(
+      method: :delete,
       path: "cursor/#{cursor_id}"
-    }
+    )
   end
 
   # @doc """
@@ -167,10 +165,9 @@ defmodule Arango.Cursor do
   # """
   @spec cursor_next(Cursor.t) :: Arango.ok_error(map)
   def cursor_next(cursor_id) do
-    %Request{
-      endpoint: :cursor,
-      http_method: :put,
+    request(
+      method: :put,
       path: "cursor/#{cursor_id}"
-    }
+    )
   end
 end

--- a/lib/arango/database.ex
+++ b/lib/arango/database.ex
@@ -1,7 +1,7 @@
 defmodule Arango.Database do
   @moduledoc "ArangoDB Database methods"
 
-  alias Arango.Request
+  use Arango.API, endpoint: :database
 
   defstruct [
     :id,
@@ -31,14 +31,13 @@ defmodule Arango.Database do
   def create(database \\ [])
   def create(%__MODULE__{name: name}), do: create(name: name)
   def create(opts) do
-    %Request{
-      endpoint: :database,
+    request(
+      method: :post,
       system_only: true,
-      http_method: :post,
       path: "database",
       body: opts |> Keyword.take([:name, :users]) |> Enum.into(%{}),
-      ok_decoder: __MODULE__.PlainDecoder,
-    }
+      ok_decoder: __MODULE__.PlainDecoder
+    )
   end
 
   @doc """
@@ -48,13 +47,12 @@ defmodule Arango.Database do
   """
   @spec drop(String.t) :: Arango.ok_error(true)
   def drop(db_name) do
-    %Request{
-      endpoint: :database,
+    request(
+      method: :delete,
       system_only: true,
-      http_method: :delete,
       path: "database/#{db_name}",
-      ok_decoder: __MODULE__.PlainDecoder,
-    }
+      ok_decoder: __MODULE__.PlainDecoder
+    )
   end
 
   @doc """
@@ -65,12 +63,11 @@ defmodule Arango.Database do
   # @type show_database_opts :: [{:name, String.t}]
   @spec database() :: Arango.ok_error(t)
   def database() do
-    %Request{
-      endpoint: :database,
-      http_method: :get,
+    request(
+      method: :get,
       path: "database/current",
-      ok_decoder: __MODULE__.DatabaseDecoder,
-    }
+      ok_decoder: __MODULE__.DatabaseDecoder
+    )
   end
 
   @doc """
@@ -80,13 +77,12 @@ defmodule Arango.Database do
   """
   @spec databases() :: Arango.ok_error([String.t])
   def databases() do
-    %Request{
-      endpoint: :database,
+    request(
+      method: :get,
       system_only: true,
-      http_method: :get,
       path: "database",
-      ok_decoder: __MODULE__.PlainDecoder,
-    }
+      ok_decoder: __MODULE__.PlainDecoder
+    )
   end
 
   @doc """
@@ -96,13 +92,12 @@ defmodule Arango.Database do
   """
   @spec user_databases() :: Arango.ok_error([String.t])
   def user_databases() do
-    %Request{
-      endpoint: :database,
+    request(
+      method: :get,
       system_only: true,           # or just /_api? Same thing?
-      http_method: :get,
       path: "database/user",
-      ok_decoder: __MODULE__.PlainDecoder,
-    }
+      ok_decoder: __MODULE__.PlainDecoder
+    )
   end
 
   defmodule DatabaseDecoder do

--- a/lib/arango/document.ex
+++ b/lib/arango/document.ex
@@ -1,9 +1,8 @@
 defmodule Arango.Document do
   @moduledoc "ArangoDB Document methods"
 
-  alias Arango.Request
+  use Arango.API, endpoint: :document
   alias Arango.Collection
-  alias Arango.Utils
 
   defmodule Docref do
     @moduledoc false
@@ -28,14 +27,13 @@ defmodule Arango.Document do
   def create(collection, document, opts \\ []) do
     query = Utils.opts_to_query(opts, [:waitForSync, :returnNew])
 
-    %Request{
-      endpoint: :document,
-      http_method: :post,
+    request(
+      method: :post,
       path: "document/#{collection.name}",
       query: query,
       body: document,
-      ok_decoder: __MODULE__.DocumentDecoder,
-    }
+      ok_decoder: __MODULE__.DocumentDecoder
+    )
   end
 
   @doc """
@@ -47,12 +45,11 @@ defmodule Arango.Document do
   def header(document, opts \\ []) do
     headers = Utils.opts_to_headers(opts, [:ifNoneMatch, :ifMatch])
 
-    %Request{
-      endpoint: :document,
-      http_method: :head,
+    request(
+      method: :head,
       path: "document/#{document._id}",
-      headers: headers,
-    }
+      headers: headers
+    )
   end
 
   @doc """
@@ -64,12 +61,11 @@ defmodule Arango.Document do
   def document(document, opts \\ []) do
     headers = Utils.opts_to_headers(opts, [:ifNoneMatch, :ifMatch])
 
-    %Request{
-      endpoint: :document,
-      http_method: :get,
+    request(
+      method: :get,
       path: "document/#{document._id}",
-      headers: headers,
-    }
+      headers: headers
+    )
   end
 
   @doc """
@@ -88,12 +84,11 @@ defmodule Arango.Document do
       true -> raise "unknown type: #{type}"
     end
 
-    %Request{
-      endpoint: :document,
-      http_method: :put,
+    request(
+      method: :put,
       path: "simple/all-keys",
-      body: body,
-    }
+      body: body
+    )
   end
 
   @doc """
@@ -107,14 +102,13 @@ defmodule Arango.Document do
   def update(collection, new_docs, opts) when is_list(new_docs) do
     query = Utils.opts_to_query(opts, [:keepNull, :mergeObjects, :waitForSync, :ignoreRevs, :returnOld, :returnNew])
 
-    %Request{
-      endpoint: :document,
-      http_method: :patch,
+    request(
+      method: :patch,
       path: "document/#{collection.name}",
       query: query,
       body: new_docs,
-      ok_decoder: __MODULE__.DocumentDecoder,
-    }
+      ok_decoder: __MODULE__.DocumentDecoder
+    )
   end
 
   @spec update(map, map, keyword) :: Arango.ok_error(map)
@@ -123,15 +117,14 @@ defmodule Arango.Document do
     headers = Utils.opts_to_headers(header_opts, [:ifMatch])
     query = Utils.opts_to_query(query_opts, [:keepNull, :mergeObjects, :waitForSync, :ignoreRevs, :returnOld, :returnNew])
 
-    %Request{
-      endpoint: :document,
-      http_method: :patch,
+    request(
+      method: :patch,
       path: "document/#{document._id}",
       query: query,
       headers: headers,
       body: new_document,
-      ok_decoder: __MODULE__.DocumentDecoder,
-    }
+      ok_decoder: __MODULE__.DocumentDecoder
+    )
   end
 
   @doc """
@@ -145,14 +138,13 @@ defmodule Arango.Document do
   def replace(collection, new_docs, opts) when is_list(new_docs) do
     query = Utils.opts_to_query(opts, [:keepNull, :mergeObjects, :waitForSync, :ignoreRevs, :returnOld, :returnNew])
 
-    %Request{
-      endpoint: :document,
-      http_method: :put,
+    request(
+      method: :put,
       path: "document/#{collection.name}",
       query: query,
       body: new_docs,
-      ok_decoder: __MODULE__.DocumentDecoder,
-    }
+      ok_decoder: __MODULE__.DocumentDecoder
+    )
   end
 
   @spec replace(t, map) :: Arango.ok_error(t | [t])
@@ -161,15 +153,14 @@ defmodule Arango.Document do
     headers = Utils.opts_to_headers(header_opts, [:ifMatch])
     query = Utils.opts_to_query(query_opts, [:keepNull, :mergeObjects, :waitForSync, :ignoreRevs, :returnOld, :returnNew])
 
-    %Request{
-      endpoint: :document,
-      http_method: :put,
+    request(
+      method: :put,
       path: "document/#{document._id}",
       query: query,
       body: new_document,
       headers: headers,
-      ok_decoder: __MODULE__.DocumentDecoder,
-    }
+      ok_decoder: __MODULE__.DocumentDecoder
+    )
   end
 
   @doc """
@@ -181,14 +172,13 @@ defmodule Arango.Document do
   def delete_multi(collection, docs, opts \\ []) when is_list(docs) do
     query = Utils.opts_to_query(opts, [:waitForSync, :ignoreRevs, :returnOld])
 
-    %Request{
-      endpoint: :document,
-      http_method: :delete,
+    request(
+      method: :delete,
       path: "document/#{collection.name}",
       query: query,
       body: docs,
-      ok_decoder: __MODULE__.DocumentDecoder,
-    }
+      ok_decoder: __MODULE__.DocumentDecoder
+    )
   end
 
   @doc """
@@ -202,14 +192,13 @@ defmodule Arango.Document do
     headers = Utils.opts_to_headers(header_opts, [:ifMatch])
     query = Utils.opts_to_query(query_opts, [:waitForSync, :returnOld])
 
-    %Request{
-      endpoint: :document,
-      http_method: :delete,
+    request(
+      method: :delete,
       path: "document/#{document._id}",
       query: query,
       headers: headers,
-      ok_decoder: __MODULE__.DocumentDecoder,
-    }
+      ok_decoder: __MODULE__.DocumentDecoder
+    )
   end
 
   defmodule DocumentDecoder do

--- a/lib/arango/graph.ex
+++ b/lib/arango/graph.ex
@@ -1,7 +1,7 @@
 defmodule Arango.Graph do
   @moduledoc "ArangoDB Graph methods"
 
-  alias Arango.Request
+  use Arango.API, endpoint: :graph
 
   defmodule EdgeDefinition do
     @moduledoc false
@@ -58,11 +58,7 @@ defmodule Arango.Graph do
   """
   @spec graphs() :: Arango.ok_error(map)
   def graphs() do
-    %Request{
-      endpoint: :graph,
-      http_method: :get,
-      path: "gharial"
-    }
+    request(method: :get, path: "gharial")
   end
 
   @doc """
@@ -78,12 +74,7 @@ defmodule Arango.Graph do
       "orphanCollections" => orphan_collections
     }
 
-    %Request{
-      endpoint: :graph,
-      http_method: :post,
-      path: "gharial",
-      body: body
-    }
+    request(method: :post, path: "gharial", body: body)
   end
 
   @doc """
@@ -93,11 +84,7 @@ defmodule Arango.Graph do
   """
   @spec drop(String.t) :: Arango.ok_error(map)
   def drop(graph_name) do
-    %Request{
-      endpoint: :graph,
-      http_method: :delete,
-      path: "gharial/#{graph_name}"
-    }
+    request(method: :delete, path: "gharial/#{graph_name}")
   end
 
   @doc """
@@ -107,11 +94,7 @@ defmodule Arango.Graph do
   """
   @spec graph(String.t) :: Arango.ok_error(map)
   def graph(graph_name) do
-    %Request{
-      endpoint: :graph,
-      http_method: :get,
-      path: "gharial/#{graph_name}"
-    }
+    request(method: :get, path: "gharial/#{graph_name}")
   end
 
   @doc """
@@ -121,11 +104,7 @@ defmodule Arango.Graph do
   """
   @spec edges(String.t) :: Arango.ok_error(map)
   def edges(graph_name) do
-    %Request{
-      endpoint: :graph,
-      http_method: :get,
-      path: "gharial/#{graph_name}/edge"
-    }
+    request(method: :get, path: "gharial/#{graph_name}/edge")
   end
 
   @doc """
@@ -137,12 +116,7 @@ defmodule Arango.Graph do
   def extend_edge_definintions(graph_name, edge_definition) do
     body = Map.from_struct(edge_definition)
 
-    %Request{
-      endpoint: :graph,
-      http_method: :post,
-      path: "gharial/#{graph_name}/edge",
-      body: body
-    }
+    request(method: :post, path: "gharial/#{graph_name}/edge", body: body)
   end
 
   @doc """
@@ -158,12 +132,7 @@ defmodule Arango.Graph do
       "_to" => edge.to,
     } |> Map.merge(edge.data || %{})
 
-    %Request{
-      endpoint: :graph,
-      http_method: :post,
-      path: "gharial/#{graph_name}/edge/#{collection_name}",
-      body: body
-    }
+    request(method: :post, path: "gharial/#{graph_name}/edge/#{collection_name}", body: body)
   end
 
   @doc """
@@ -173,11 +142,7 @@ defmodule Arango.Graph do
   """
   @spec edge_delete(String.t, String.t, String.t) :: Arango.ok_error(map)
   def edge_delete(graph_name, collection_name, edge_key) do
-    %Request{
-      endpoint: :graph,
-      http_method: :delete,
-      path: "gharial/#{graph_name}/edge/#{collection_name}/#{edge_key}"
-    }
+    request(method: :delete, path: "gharial/#{graph_name}/edge/#{collection_name}/#{edge_key}")
   end
 
   @doc """
@@ -187,11 +152,7 @@ defmodule Arango.Graph do
   """
   @spec edge(String.t, String.t, String.t) :: Arango.ok_error(map)
   def edge(graph_name, collection_name, edge_key) do
-    %Request{
-      endpoint: :graph,
-      http_method: :get,
-      path: "gharial/#{graph_name}/edge/#{collection_name}/#{edge_key}"
-    }
+    request(method: :get, path: "gharial/#{graph_name}/edge/#{collection_name}/#{edge_key}")
   end
 
   @doc """
@@ -201,12 +162,11 @@ defmodule Arango.Graph do
   """
   @spec edge_update(String.t, String.t, String.t, map) :: Arango.ok_error(map)
   def edge_update(graph_name, collection_name, edge_key, edge_body) do
-    %Request{
-      endpoint: :graph,
-      http_method: :patch,
+    request(
+      method: :patch,
       path: "gharial/#{graph_name}/edge/#{collection_name}/#{edge_key}",
       body: edge_body
-    }
+    )
   end
 
   @doc """
@@ -222,12 +182,11 @@ defmodule Arango.Graph do
       "_to" => edge.to,
     } |> Map.merge(edge.data || %{})
 
-    %Request{
-      endpoint: :graph,
-      http_method: :put,
+    request(
+      method: :put,
       path: "gharial/#{graph_name}/edge/#{collection_name}/#{edge_key}",
       body: body
-    }
+    )
   end
 
   @doc """
@@ -237,11 +196,7 @@ defmodule Arango.Graph do
   """
   @spec edge_definition_delete(String.t, String.t) :: Arango.ok_error(map)
   def edge_definition_delete(graph_name, edge_definition_name) do
-    %Request{
-      endpoint: :graph,
-      http_method: :delete,
-      path: "gharial/#{graph_name}/edge/#{edge_definition_name}"
-    }
+    request(method: :delete, path: "gharial/#{graph_name}/edge/#{edge_definition_name}")
   end
 
   @doc """
@@ -251,12 +206,11 @@ defmodule Arango.Graph do
   """
   @spec edge_definition_replace(String.t, String.t, EdgeDefinition.t) :: Arango.ok_error(map)
   def edge_definition_replace(graph_name, edge_definition_name, edge_definition) do
-    %Request{
-      endpoint: :graph,
-      http_method: :put,
+    request(
+      method: :put,
       path: "gharial/#{graph_name}/edge/#{edge_definition_name}",
       body: edge_definition
-    }
+    )
   end
 
   @doc """
@@ -266,11 +220,7 @@ defmodule Arango.Graph do
   """
   @spec vertex_collections(String.t) :: Arango.ok_error(map)
   def vertex_collections(graph_name) do
-    %Request{
-      endpoint: :graph,
-      http_method: :get,
-      path: "gharial/#{graph_name}/vertex",
-    }
+    request(method: :get, path: "gharial/#{graph_name}/vertex")
   end
 
   @doc """
@@ -282,12 +232,7 @@ defmodule Arango.Graph do
   def vertex_collection_create(graph_name, vertex_collection) do
     body = Map.from_struct(vertex_collection)
 
-    %Request{
-      endpoint: :graph,
-      http_method: :post,
-      path: "gharial/#{graph_name}/vertex",
-      body: body
-    }
+    request(method: :post, path: "gharial/#{graph_name}/vertex", body: body)
   end
 
   @doc """
@@ -297,11 +242,7 @@ defmodule Arango.Graph do
   """
   @spec vertex_collection_delete(String.t, String.t) :: Arango.ok_error(map)
   def vertex_collection_delete(graph_name, collection_name) do
-    %Request{
-      endpoint: :graph,
-      http_method: :delete,
-      path: "gharial/#{graph_name}/vertex/#{collection_name}",
-    }
+    request(method: :delete, path: "gharial/#{graph_name}/vertex/#{collection_name}")
   end
 
   @doc """
@@ -311,12 +252,11 @@ defmodule Arango.Graph do
   """
   @spec vertex_create(String.t, String.t, map) :: Arango.ok_error(map)
   def vertex_create(graph_name, collection_name, vertex_body) do
-    %Request{
-      endpoint: :graph,
-      http_method: :post,
+    request(
+      method: :post,
       path: "gharial/#{graph_name}/vertex/#{collection_name}",
       body: vertex_body
-    }
+    )
   end
 
   @doc """
@@ -326,11 +266,7 @@ defmodule Arango.Graph do
   """
   @spec vertex_delete(String.t, String.t, String.t) :: Arango.ok_error(map)
   def vertex_delete(graph_name, collection_name, vertex_key) do
-    %Request{
-      endpoint: :graph,
-      http_method: :delete,
-      path: "gharial/#{graph_name}/vertex/#{collection_name}/#{vertex_key}",
-    }
+    request(method: :delete, path: "gharial/#{graph_name}/vertex/#{collection_name}/#{vertex_key}")
   end
 
   @doc """
@@ -340,11 +276,7 @@ defmodule Arango.Graph do
   """
   @spec vertex(String.t, String.t, String.t) :: Arango.ok_error(map)
   def vertex(graph_name, collection_name, vertex_key) do
-    %Request{
-      endpoint: :graph,
-      http_method: :get,
-      path: "gharial/#{graph_name}/vertex/#{collection_name}/#{vertex_key}",
-    }
+    request(method: :get, path: "gharial/#{graph_name}/vertex/#{collection_name}/#{vertex_key}")
   end
 
   @doc """
@@ -354,12 +286,11 @@ defmodule Arango.Graph do
   """
   @spec vertex_update(String.t, String.t, String.t, map) :: Arango.ok_error(map)
   def vertex_update(graph_name, collection_name, vertex_key, vertex_body) do
-    %Request{
-      endpoint: :graph,
-      http_method: :patch,
+    request(
+      method: :patch,
       path: "gharial/#{graph_name}/vertex/#{collection_name}/#{vertex_key}",
       body: vertex_body
-    }
+    )
   end
 
   @doc """
@@ -369,11 +300,10 @@ defmodule Arango.Graph do
   """
   @spec vertex_replace(String.t, String.t, String.t, map) :: Arango.ok_error(map)
   def vertex_replace(graph_name, collection_name, vertex_key, vertex_body) do
-    %Request{
-      endpoint: :graph,
-      http_method: :put,
+    request(
+      method: :put,
       path: "gharial/#{graph_name}/vertex/#{collection_name}/#{vertex_key}",
       body: vertex_body
-    }
+    )
   end
 end

--- a/lib/arango/graph_edge.ex
+++ b/lib/arango/graph_edge.ex
@@ -1,8 +1,7 @@
 defmodule Arango.GraphEdge do
   @moduledoc "ArangoDB Graph Edge methods"
 
-  alias Arango.Request
-  alias Arango.Utils
+  use Arango.API, endpoint: :graph_edge
 
   @doc """
   Read in or outbound edges
@@ -16,11 +15,10 @@ defmodule Arango.GraphEdge do
               nil -> Utils.opts_to_query([vertex: vertex_id], [:vertex])
             end
 
-    %Request{
-      endpoint: :graph_edge,
-      http_method: :get,
+    request(
+      method: :get,
       path: "edges/#{collection_name}",
-      query: query,
-    }
+      query: query
+    )
   end
 end

--- a/lib/arango/index.ex
+++ b/lib/arango/index.ex
@@ -1,8 +1,7 @@
 defmodule Arango.Index do
   @moduledoc "ArangoDB Index methods"
 
-  alias Arango.Request
-  alias Arango.Utils
+  use Arango.API, endpoint: :index
 
   @doc """
   Read index
@@ -11,11 +10,7 @@ defmodule Arango.Index do
   """
   @spec index(String.t) :: Arango.ok_error(map)
   def index(index_handle) do
-    %Request{
-      endpoint: :index,
-      http_method: :get,
-      path: "index/#{index_handle}",
-    }
+    request(method: :get, path: "index/#{index_handle}")
   end
 
   @doc """
@@ -27,12 +22,7 @@ defmodule Arango.Index do
   def indexes(collection_name) do
     query = Utils.opts_to_query([collection: collection_name], [:collection])
 
-    %Request{
-      endpoint: :index,
-      http_method: :get,
-      path: "index",
-      query: query,
-    }
+    request(method: :get, path: "index", query: query)
   end
 
   @doc """
@@ -50,13 +40,7 @@ defmodule Arango.Index do
       "minLength" => properties["minLength"] || 0
     }
 
-    %Request{
-      endpoint: :index,
-      http_method: :post,
-      path: "index/",
-      query: query,
-      body: body,
-    }
+    request(method: :post, path: "index/", query: query, body: body)
   end
 
   @doc """
@@ -68,13 +52,7 @@ defmodule Arango.Index do
   def create_general(collection_name, body) do
     query = Utils.opts_to_query([collection: collection_name], [:collection])
 
-    %Request{
-      endpoint: :index,
-      http_method: :post,
-      path: "index/",
-      query: query,
-      body: body,
-    }
+    request(method: :post, path: "index/", query: query, body: body)
   end
 
   @doc """
@@ -92,13 +70,7 @@ defmodule Arango.Index do
       "geoJson" => properties["geoJson"] || false
     }
 
-    %Request{
-      endpoint: :index,
-      http_method: :post,
-      path: "index/",
-      query: query,
-      body: body,
-    }
+    request(method: :post, path: "index/", query: query, body: body)
   end
 
   @doc """
@@ -115,13 +87,7 @@ defmodule Arango.Index do
       |> Utils.opts_to_vars([:unique, :sparse])
       |> Map.merge(%{"type" => "hash", "fields" => field_names})
 
-    %Request{
-      endpoint: :index,
-      http_method: :post,
-      path: "index/",
-      query: query,
-      body: body,
-    }
+    request(method: :post, path: "index/", query: query, body: body)
   end
 
   @doc """
@@ -137,13 +103,7 @@ defmodule Arango.Index do
       |> Utils.opts_to_vars([:unique, :sparse])
       |> Map.merge(%{"type" => "persistent", "fields" => field_names})
 
-    %Request{
-      endpoint: :index,
-      http_method: :post,
-      path: "index/",
-      query: query,
-      body: body,
-    }
+    request(method: :post, path: "index/", query: query, body: body)
   end
 
   @doc """
@@ -160,13 +120,7 @@ defmodule Arango.Index do
       |> Utils.opts_to_vars([:unique, :sparse])
       |> Map.merge(%{"type" => "skiplist", "fields" => field_names})
 
-    %Request{
-      endpoint: :index,
-      http_method: :post,
-      path: "index/",
-      query: query,
-      body: body,
-    }
+    request(method: :post, path: "index/", query: query, body: body)
   end
 
   @doc """
@@ -176,10 +130,6 @@ defmodule Arango.Index do
   """
   @spec delete(String.t) :: Arango.ok_error(map)
   def delete(index_handle) do
-    %Request{
-      endpoint: :index,
-      http_method: :delete,
-      path: "index/#{index_handle}",
-    }
+    request(method: :delete, path: "index/#{index_handle}")
   end
 end

--- a/lib/arango/simple.ex
+++ b/lib/arango/simple.ex
@@ -9,8 +9,7 @@ defmodule Arango.Simple do
   > removed when ArangoDB 4.0 (API v1) becomes the default.
   """
 
-  alias Arango.Request
-  alias Arango.Utils
+  use Arango.API, endpoint: :simple
   alias Arango.Collection
 
   @deprecation "Use AQL via Arango.Cursor.create/1. Removed in v1/4.0."
@@ -26,12 +25,7 @@ defmodule Arango.Simple do
     vars = Utils.opts_to_vars(opts, [:skip, :limit])
     body = Map.merge(%{collection: collection.name}, vars)
 
-    %Request{
-      endpoint: :simple,
-      http_method: :put,
-      path: "simple/all",
-      body: body,
-    }
+    request(method: :put, path: "simple/all", body: body)
   end
 
   @doc """
@@ -42,12 +36,7 @@ defmodule Arango.Simple do
   @deprecated @deprecation
   @spec any(Collection.t) :: Arango.ok_error(map)
   def any(collection) do
-    %Request{
-      endpoint: :simple,
-      http_method: :put,
-      path: "simple/any",
-      body: %{collection: collection.name},
-    }
+    request(method: :put, path: "simple/any", body: %{collection: collection.name})
   end
 
   @doc """
@@ -61,12 +50,7 @@ defmodule Arango.Simple do
     vars = Utils.opts_to_vars(opts, [:skip, :limit])
     body = Map.merge(%{collection: collection.name, example: example}, vars)
 
-    %Request{
-      endpoint: :simple,
-      http_method: :put,
-      path: "simple/by-example",
-      body: body,
-    }
+    request(method: :put, path: "simple/by-example", body: body)
   end
 
   @doc """
@@ -77,12 +61,11 @@ defmodule Arango.Simple do
   @deprecated @deprecation
   @spec find_by_example(Collection.t, map) :: Arango.ok_error(map)
   def find_by_example(collection, example) do
-    %Request{
-      endpoint: :simple,
-      http_method: :put,
+    request(
+      method: :put,
       path: "simple/first-example",
-      body: %{collection: collection.name, example: example},
-    }
+      body: %{collection: collection.name, example: example}
+    )
   end
 
   @doc """
@@ -100,12 +83,7 @@ defmodule Arango.Simple do
       "query" => query
     }, vars)
 
-    %Request{
-      endpoint: :simple,
-      http_method: :put,
-      path: "simple/fulltext",
-      body: body,
-    }
+    request(method: :put, path: "simple/fulltext", body: body)
   end
 
   @doc """
@@ -121,12 +99,7 @@ defmodule Arango.Simple do
       "keys" => keys
     }
 
-    %Request{
-      endpoint: :simple,
-      http_method: :put,
-      path: "simple/lookup-by-keys",
-      body: body,
-    }
+    request(method: :put, path: "simple/lookup-by-keys", body: body)
   end
 
   @doc """
@@ -146,12 +119,7 @@ defmodule Arango.Simple do
       "right" => right,
     }, vars)
 
-    %Request{
-      endpoint: :simple,
-      http_method: :put,
-      path: "simple/range",
-      body: body,
-    }
+    request(method: :put, path: "simple/range", body: body)
   end
 
   @doc """
@@ -169,12 +137,7 @@ defmodule Arango.Simple do
       "options" => Map.merge(%{}, vars)
     }
 
-    %Request{
-      endpoint: :simple,
-      http_method: :put,
-      path: "simple/remove-by-example",
-      body: body,
-    }
+    request(method: :put, path: "simple/remove-by-example", body: body)
   end
 
   @doc """
@@ -192,12 +155,7 @@ defmodule Arango.Simple do
       "options" => Map.merge(%{}, vars)
     }
 
-    %Request{
-      endpoint: :simple,
-      http_method: :put,
-      path: "simple/remove-by-keys",
-      body: body,
-    }
+    request(method: :put, path: "simple/remove-by-keys", body: body)
   end
 
   @doc """
@@ -216,12 +174,7 @@ defmodule Arango.Simple do
       "options" => Map.merge(%{}, vars)
     }
 
-    %Request{
-      endpoint: :simple,
-      http_method: :put,
-      path: "simple/replace-by-example",
-      body: body,
-    }
+    request(method: :put, path: "simple/replace-by-example", body: body)
   end
 
   @doc """
@@ -240,12 +193,7 @@ defmodule Arango.Simple do
       "options" => Map.merge(%{}, vars)
     }
 
-    %Request{
-      endpoint: :simple,
-      http_method: :put,
-      path: "simple/update-by-example",
-      body: body,
-    }
+    request(method: :put, path: "simple/update-by-example", body: body)
   end
 
 
@@ -264,12 +212,7 @@ defmodule Arango.Simple do
       "longitude" => longitude,
     }, vars)
 
-    %Request{
-      endpoint: :simple,
-      http_method: :put,
-      path: "simple/near",
-      body: body,
-    }
+    request(method: :put, path: "simple/near", body: body)
   end
 
   @doc """
@@ -289,12 +232,7 @@ defmodule Arango.Simple do
       "radius" => radius,
     }, vars)
 
-    %Request{
-      endpoint: :simple,
-      http_method: :put,
-      path: "simple/within",
-      body: body,
-    }
+    request(method: :put, path: "simple/within", body: body)
   end
 
   @doc """
@@ -315,11 +253,6 @@ defmodule Arango.Simple do
       "longitude2" => longitude2,
     }, vars)
 
-    %Request{
-      endpoint: :simple,
-      http_method: :put,
-      path: "simple/within-rectangle",
-      body: body,
-    }
+    request(method: :put, path: "simple/within-rectangle", body: body)
   end
 end

--- a/lib/arango/task.ex
+++ b/lib/arango/task.ex
@@ -8,7 +8,7 @@ defmodule Arango.Task do
   > scheduler (cron, Quantum, Oban) instead.
   """
 
-  alias Arango.Request
+  use Arango.API, endpoint: :task
 
   @deprecation "Removed in API v1/4.0. Use an external scheduler (cron, Quantum, Oban)."
 
@@ -46,13 +46,12 @@ defmodule Arango.Task do
   @deprecated @deprecation
   @spec create(t) :: Arango.ok_error(map)
   def create(task) do
-    %Request{
-      endpoint: :task,
-      system_only: true,   # or just /_api? Same thing?
-      http_method: :post,
+    request(
+      system_only: true,
+      method: :post,
       path: "tasks",
       body: task
-    }
+    )
   end
 
   @doc """
@@ -63,12 +62,11 @@ defmodule Arango.Task do
   @deprecated @deprecation
   @spec tasks() :: Arango.ok_error(map)
   def tasks() do
-    %Request{
-      endpoint: :task,
-      system_only: true,   # or just /_api? Same thing?
-      http_method: :get,
-      path: "tasks",
-    }
+    request(
+      system_only: true,
+      method: :get,
+      path: "tasks"
+    )
   end
 
   @doc """
@@ -79,12 +77,11 @@ defmodule Arango.Task do
   @deprecated @deprecation
   @spec delete(String.t) :: Arango.ok_error(map)
   def delete(task_id) do
-    %Request{
-      endpoint: :task,
-      system_only: true,   # or just /_api? Same thing?
-      http_method: :delete,
-      path: "tasks/#{task_id}",
-    }
+    request(
+      system_only: true,
+      method: :delete,
+      path: "tasks/#{task_id}"
+    )
   end
 
   @doc """
@@ -95,12 +92,11 @@ defmodule Arango.Task do
   @deprecated @deprecation
   @spec task(String.t) :: Arango.ok_error(map)
   def task(task_id) do
-    %Request{
-      endpoint: :task,
-      system_only: true,   # or just /_api? Same thing?
-      http_method: :get,
-      path: "tasks/#{task_id}",
-    }
+    request(
+      system_only: true,
+      method: :get,
+      path: "tasks/#{task_id}"
+    )
   end
 
   @doc """
@@ -111,12 +107,11 @@ defmodule Arango.Task do
   @deprecated @deprecation
   @spec create_with_id(String.t, Task.t) :: Arango.ok_error(map)
   def create_with_id(task_id, task) do
-    %Request{
-      endpoint: :task,
-      system_only: true,   # or just /_api? Same thing?
-      http_method: :put,
+    request(
+      system_only: true,
+      method: :put,
       path: "tasks/#{task_id}",
-      body: task,
-    }
+      body: task
+    )
   end
 end

--- a/lib/arango/transaction.ex
+++ b/lib/arango/transaction.ex
@@ -1,7 +1,7 @@
 defmodule Arango.Transaction do
   @moduledoc "ArangoDB Transaction methods"
 
-  alias Arango.Request
+  use Arango.API, endpoint: :transaction
 
   defmodule Transaction do
     @moduledoc false
@@ -76,11 +76,10 @@ defmodule Arango.Transaction do
       |> Map.merge(if t.lock_timeout, do: %{"lockTimeout" => t.lock_timeout}, else: %{})
       |> Map.merge(if t.wait_for_sync, do: %{"waitForSync" => t.wait_for_sync}, else: %{})
 
-    %Request{
-      endpoint: :transaction,
-      http_method: :post,
+    request(
+      method: :post,
       path: "transaction",
-      body: body,
-    }
+      body: body
+    )
   end
 end

--- a/lib/arango/user.ex
+++ b/lib/arango/user.ex
@@ -1,8 +1,7 @@
 defmodule Arango.User do
   @moduledoc "ArangoDB User methods"
 
-  alias Arango.Request
-  alias Arango.Utils
+  use Arango.API, endpoint: :user
 
   defstruct [
     user: nil,
@@ -31,14 +30,13 @@ defmodule Arango.User do
   def create(user \\ [])
   def create(%__MODULE__{user: name}), do: create(user: name)
   def create(opts) do
-    %Request{
-      endpoint: :user,
+    request(
+      method: :post,
       system_only: true,   # or just /_api? Same thing?
-      http_method: :post,
       path: "user",
       body: opts |> Keyword.take([:user, :passwd, :active, :extra]) |> Enum.into(%{}),
-      ok_decoder: __MODULE__.UserDecoder,
-    }
+      ok_decoder: __MODULE__.UserDecoder
+    )
   end
 
   @doc """
@@ -49,12 +47,11 @@ defmodule Arango.User do
   @spec remove(t | String.t) :: Arango.ok_error(map)
   def remove(%__MODULE__{user: name}), do: remove(name)
   def remove(name) do
-    %Request{
-      endpoint: :user,
+    request(
+      method: :delete,
       system_only: true,   # or just /_api? Same thing?
-      http_method: :delete,
-      path: "user/#{name}",
-    }
+      path: "user/#{name}"
+    )
   end
 
   @doc """
@@ -64,13 +61,12 @@ defmodule Arango.User do
   """
   @spec users() :: Arango.ok_error([t])
   def users() do
-    %Request{
-      endpoint: :user,
-            system_only: true,   # or just /_api? Same thing?
-      http_method: :get,
+    request(
+      method: :get,
+      system_only: true,   # or just /_api? Same thing?
       path: "user",
-      ok_decoder: __MODULE__.UserDecoder,
-    }
+      ok_decoder: __MODULE__.UserDecoder
+    )
   end
 
   @doc """
@@ -81,13 +77,12 @@ defmodule Arango.User do
   @spec user(String.t | t) :: Arango.ok_error(t)
   def user(%__MODULE__{user: name}), do: user(name)
   def user(name) do
-    %Request{
-      endpoint: :user,
+    request(
+      method: :get,
       system_only: true,   # or just /_api? Same thing?
-      http_method: :get,
       path: "user/#{name}",
-      ok_decoder: __MODULE__.UserDecoder,
-    }
+      ok_decoder: __MODULE__.UserDecoder
+    )
   end
 
   @doc """
@@ -99,14 +94,13 @@ defmodule Arango.User do
   def update(user, opts \\ []) do
     properties = Utils.opts_to_vars(opts, [:passwd, :active, :extra])
 
-    %Request{
-      endpoint: :user,
+    request(
+      method: :patch,
       system_only: true,   # or just /_api? Same thing?
-      http_method: :patch,
       path: "user/#{user.user}",
       body: properties,
-      ok_decoder: __MODULE__.UserDecoder,
-    }
+      ok_decoder: __MODULE__.UserDecoder
+    )
   end
 
   @doc """
@@ -118,14 +112,13 @@ defmodule Arango.User do
   def replace(user, opts \\ []) do
     properties = Utils.opts_to_vars(opts, [:passwd, :active, :extra])
 
-    %Request{
-      endpoint: :user,
+    request(
+      method: :put,
       system_only: true,   # or just /_api? Same thing?
-      http_method: :put,
       path: "user/#{user.user}",
       body: properties,
-      ok_decoder: __MODULE__.UserDecoder,
-    }
+      ok_decoder: __MODULE__.UserDecoder
+    )
   end
 
   @doc """
@@ -136,13 +129,12 @@ defmodule Arango.User do
   @spec databases(String.t | t) :: Arango.ok_error([String.t])
   def databases(%__MODULE__{user: name}), do: databases(name)
   def databases(user_name) do
-    %Request{
-      endpoint: :user,
+    request(
+      method: :get,
       system_only: true,   # or just /_api? Same thing?
-      http_method: :get,
       path: "user/#{user_name}/database",
-      ok_decoder: __MODULE__.PlainDecoder,
-    }
+      ok_decoder: __MODULE__.PlainDecoder
+    )
   end
 
   @doc """
@@ -153,13 +145,12 @@ defmodule Arango.User do
   @spec grant(t, Database.t) :: Arango.ok_error([String.t])
   def grant(%__MODULE__{user: user_name}, database_name), do: grant(user_name, database_name)
   def grant(user_name, database_name) do
-    %Request{
-      endpoint: :user,
+    request(
+      method: :put,
       system_only: true,   # or just /_api? Same thing?
-      http_method: :put,
       path: "user/#{user_name}/database/#{database_name}",
-      body: %{grant: "rw"},
-    }
+      body: %{grant: "rw"}
+    )
   end
 
   @doc """
@@ -170,13 +161,12 @@ defmodule Arango.User do
   @spec revoke(t, Database.t) :: Arango.ok_error([String.t])
   def revoke(%__MODULE__{user: user_name}, database_name), do: revoke(user_name, database_name)
   def revoke(user_name, database_name) do
-    %Request{
-      endpoint: :user,
+    request(
+      method: :put,
       system_only: true,   # or just /_api? Same thing?
-      http_method: :put,
       path: "user/#{user_name}/database/#{database_name}",
-      body: %{grant: "none"},
-    }
+      body: %{grant: "none"}
+    )
   end
 
   defmodule UserDecoder do

--- a/lib/arango/wal.ex
+++ b/lib/arango/wal.ex
@@ -1,8 +1,7 @@
 defmodule Arango.Wal do
   @moduledoc "ArangoDB Wal methods"
 
-  alias Arango.Request
-  alias Arango.Utils
+  use Arango.API, endpoint: :wal
 
   defstruct [
     :allowOversizeEntries,
@@ -34,13 +33,12 @@ defmodule Arango.Wal do
   def flush(opts \\ []) do
     flush_opts = Utils.opts_to_vars(opts, [:waitForSync, :waitForCollector])
 
-    %Request{
-      endpoint: :wal,
+    request(
+      method: :put,
       system_only: true,   # or just /_api? Same thing?
-      http_method: :put,
       path: "/_admin/wal/flush",
-      body: flush_opts,
-    }
+      body: flush_opts
+    )
   end
 
   @doc """
@@ -50,13 +48,12 @@ defmodule Arango.Wal do
   """
   @spec properties() :: Arango.ok_error(t)
   def properties() do
-    %Request{
-      endpoint: :wal,
+    request(
+      method: :get,
       system_only: true,   # or just /_api? Same thing?
-      http_method: :get,
       path: "/_admin/wal/properties",
-      ok_decoder: __MODULE__.WalDecoder,
-    }
+      ok_decoder: __MODULE__.WalDecoder
+    )
   end
 
   @doc """
@@ -70,14 +67,13 @@ defmodule Arango.Wal do
     defaults = %__MODULE__{} |> Map.from_struct |> Map.keys
     wal_properties = Utils.opts_to_vars(properties, defaults)
 
-    %Request{
-      endpoint: :wal,
+    request(
+      method: :put,
       system_only: true,   # or just /_api? Same thing?
-      http_method: :put,
       path: "/_admin/wal/properties",
       body: wal_properties,
-      ok_decoder: __MODULE__.WalDecoder,
-    }
+      ok_decoder: __MODULE__.WalDecoder
+    )
   end
 
   @doc """
@@ -87,12 +83,11 @@ defmodule Arango.Wal do
   """
   @spec transactions() :: Arango.ok_error(map)
   def transactions() do
-    %Request{
-      endpoint: :wal,
+    request(
+      method: :get,
       system_only: true,   # or just /_api? Same thing?
-      http_method: :get,
-      path: "/_admin/wal/transactions",
-    }
+      path: "/_admin/wal/transactions"
+    )
   end
 
   defmodule WalDecoder do

--- a/plans/00-overview.md
+++ b/plans/00-overview.md
@@ -9,7 +9,7 @@ Target: ArangoDB 3.12+ (API v0), modern Elixir, HTTP+JSON only.
 | 1 | [Deps modernization](./01-deps-modernization.md) | done |
 | 1a | [Test harness](./01a-test-harness.md) | done — 226 pass / 0 fail / 4 skip (3.12) |
 | 3 | [Deprecate & remove](./03-remove-dead-modules.md) | done — 210 pass / 0 fail / 11 skip |
-| 2 | [Extract macros](./02-extract-macros.md) | needs detailed plan |
+| 2 | [Extract macros](./02-extract-macros.md) | done — 14 modules on `Arango.API`, 210 pass / 0 fail / 11 skip |
 | 4 | [Update existing modules to 3.12](./04-update-existing.md) | planned |
 | 5 | [Add Views, Analyzers, Stream Tx](./05-new-apis.md) | planned |
 | 6 | [Quality of life (request!, stream!, JWT)](./06-quality-of-life.md) | planned |

--- a/plans/02-extract-macros.md
+++ b/plans/02-extract-macros.md
@@ -1,6 +1,6 @@
 # Phase 2: Extract Macros
 
-Status: planned
+Status: done — `Arango.API` macro at `lib/arango/api.ex` provides `use Arango.API, endpoint: :foo` (pins `@endpoint`, aliases `Request`/`Utils`) and `request(method: X, path: Y, ...)` (builds `%Request{}` with endpoint pre-filled, `:method` → `:http_method`). All 14 API modules converted: administration, aql, collection, cursor, database, document, graph, graph_edge, index, simple, task, transaction, user, wal. Decoder helpers deferred — too many shapes (PlainDecoder, struct-list/single, custom list+to_document) for a single macro to be a win. 210 pass / 0 fail / 11 skip.
 
 ## Goal
 
@@ -47,6 +47,16 @@ end
 2. Convert `Collection` module as proof of concept
 3. Run collection tests to verify
 4. Convert remaining modules one at a time, testing each
+
+## Pre-coding tasks
+
+Before writing the macros, we need to:
+
+1. **Pick 5-10 representative call sites** from different modules and write before/after pairs by hand. This validates the macro design holds up across the variety of patterns (simple GET, POST with body, opts splitting, decoder-using, system_only, etc.).
+2. **Decide on quoted-syntax mechanics**:
+   - `@endpoint` module attribute or implicit from `use` macro?
+   - How does the macro know about the module's nested decoders?
+3. **Decide test strategy**: do macros get their own unit tests, or only integration via existing module tests?
 
 ## Files to Change
 


### PR DESCRIPTION
## Summary

- New `lib/arango/api.ex` provides:
  - `use Arango.API, endpoint: :foo` — pins `@endpoint`, aliases `Request`/`Utils`
  - `request(method: X, path: Y, ...)` — builds `%Request{}` with endpoint pre-filled, renames `:method` → `:http_method`
- All 14 API modules converted to the macro (administration, aql, collection, cursor, database, document, graph, graph_edge, index, simple, task, transaction, user, wal).
- Decoder helpers deferred — 5+ shapes (PlainDecoder, struct list+single, custom `to_document`) make a single macro a net loss.

Reference: `plans/02-extract-macros.md`. -640 lines net across `lib/`.

**Stacked on #3** — merge that one first or rebase if it changes.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 210 pass / 0 fail / 11 skip (matches Phase 3 baseline)
- [ ] Skim `lib/arango/api.ex` — macro feels right?
- [ ] Spot-check 2-3 converted modules for fidelity (e.g., `collection.ex` is the POC)