### PR TITLE
Replace conditional body-merge chains with Utils.compact/1

### DIFF
--- a/lib/arango/aql.ex
+++ b/lib/arango/aql.ex
@@ -134,28 +134,20 @@ defmodule Arango.Aql do
   """
   @spec explain_query(Keyword.t) :: Arango.ok_error(map)
   def explain_query(query, options \\ %{}) do
-    # TODO: this is surely simplified with a reduce
     options = Enum.into(options, %{})
-
-    max_number_of_plans = Map.get(options, :max_number_of_plans)
-    all_plans = Map.get(options, :all_plans)
     optimizer_rules = Map.get(options, :optimizer_rules)
 
     opts =
-      %{}
-      |> Map.merge(if max_number_of_plans, do: %{"maxNumberOfPlans" => max_number_of_plans}, else: %{})
-      |> Map.merge(if all_plans, do: %{"allPlans" => all_plans}, else: %{})
-      |> Map.merge(if optimizer_rules, do: %{"optimizer" => %{"rules" => optimizer_rules}}, else: %{})
+      Utils.compact(%{
+        "maxNumberOfPlans" => Map.get(options, :max_number_of_plans),
+        "allPlans" => Map.get(options, :all_plans),
+        "optimizer" => optimizer_rules && %{"rules" => optimizer_rules}
+      })
 
     explain_request =
-      %{query: query}
-      |> Map.merge(if Enum.any?(opts), do: %{"options" => opts}, else: %{})
+      if map_size(opts) > 0, do: %{:query => query, "options" => opts}, else: %{query: query}
 
-    request(
-      method: :post,
-      path: "explain",
-      body: explain_request
-    )
+    request(method: :post, path: "explain", body: explain_request)
   end
 
   @doc """
@@ -207,19 +199,13 @@ defmodule Arango.Aql do
   def set_query_cache_properties(options \\ %{}) do
     options = Enum.into(options, %{})
 
-    max_results = Map.get(options, :max_results)
-    mode = Map.get(options, :mode)
-
     opts =
-      %{}
-      |> Map.merge(if max_results, do: %{"maxResults" => max_results}, else: %{})
-      |> Map.merge(if mode, do: %{"mode" => mode}, else: %{})
+      Utils.compact(%{
+        "maxResults" => Map.get(options, :max_results),
+        "mode" => Map.get(options, :mode)
+      })
 
-    request(
-      method: :put,
-      path: "query-cache/properties",
-      body: opts
-    )
+    request(method: :put, path: "query-cache/properties", body: opts)
   end
 
   @doc """
@@ -257,25 +243,16 @@ defmodule Arango.Aql do
   def set_query_properties(options \\ %{}) do
     options = Enum.into(options, %{})
 
-    enabled = Map.get(options, :enabled)
-    slow_query_threshold = Map.get(options, :slow_query_threshold)
-    max_slow_queries = Map.get(options, :max_slow_queries)
-    track_slow_queries = Map.get(options, :track_slow_queries)
-    max_query_string_length = Map.get(options, :max_query_string_length)
-
     opts =
-      %{}
-      |> Map.merge(if enabled, do: %{"enabled" => enabled}, else: %{})
-      |> Map.merge(if slow_query_threshold, do: %{"slowQuerythreshold" => slow_query_threshold}, else: %{})
-      |> Map.merge(if max_slow_queries, do: %{"maxSlowqueries" => max_slow_queries}, else: %{})
-      |> Map.merge(if track_slow_queries, do: %{"trackSlowqueries" => track_slow_queries}, else: %{})
-      |> Map.merge(if max_query_string_length, do: %{"maxQuerystringlength" => max_query_string_length}, else: %{})
+      Utils.compact(%{
+        "enabled" => Map.get(options, :enabled),
+        "slowQueryThreshold" => Map.get(options, :slow_query_threshold),
+        "maxSlowQueries" => Map.get(options, :max_slow_queries),
+        "trackSlowQueries" => Map.get(options, :track_slow_queries),
+        "maxQueryStringLength" => Map.get(options, :max_query_string_length)
+      })
 
-    request(
-      method: :put,
-      path: "query/properties",
-      body: opts
-    )
+    request(method: :put, path: "query/properties", body: opts)
   end
 
   @doc """

--- a/lib/arango/cursor.ex
+++ b/lib/arango/cursor.ex
@@ -122,21 +122,22 @@ defmodule Arango.Cursor do
     optimizer_rules = Map.get(cursor, :optimizer_rules)
 
     top_level =
-      %{}
-      |> Map.merge(if query, do: %{"query" => query}, else: %{})
-      |> Map.merge(if bind_vars, do: %{"bindVars" => Enum.into(bind_vars, %{})}, else: %{})
-      |> Map.merge(if count, do: %{"count" => count}, else: %{})
-      |> Map.merge(if batch_size, do: %{"batchSize" => batch_size}, else: %{})
+      Utils.compact(%{
+        "query" => query,
+        "bindVars" => bind_vars && Enum.into(bind_vars, %{}),
+        "count" => count,
+        "batchSize" => batch_size
+      })
 
     options =
-      %{}
-      |> Map.merge(if full_count, do: %{"fullCount" => full_count}, else: %{})
-      |> Map.merge(if max_plans, do: %{"maxPlans" => max_plans}, else: %{})
-      |> Map.merge(if optimizer_rules, do: %{"optimizer" => %{"rules" => optimizer_rules}}, else: %{})
+      Utils.compact(%{
+        "fullCount" => full_count,
+        "maxPlans" => max_plans,
+        "optimizer" => optimizer_rules && %{"rules" => optimizer_rules}
+      })
 
     cursor_request =
-      top_level
-      |> Map.merge(if Enum.any?(options), do: %{"options" => options}, else: %{})
+      if map_size(options) > 0, do: Map.put(top_level, "options", options), else: top_level
 
     request(
       method: :post,

--- a/lib/arango/transaction.ex
+++ b/lib/arango/transaction.ex
@@ -65,16 +65,20 @@ defmodule Arango.Transaction do
   @spec transaction(Transaction.t) :: Arango.ok_error(map)
   def transaction(t) do
     collections =
-      %{}
-      |> Map.merge(if t.read_collections, do: %{"read" => t.read_collections}, else: %{})
-      |> Map.merge(if t.write_collections, do: %{"write" => t.write_collections}, else: %{})
-      |> Map.merge(if t.allow_implicit == false, do: %{"allowImplicit" => false}, else: %{})
+      Utils.compact(%{
+        "read" => t.read_collections,
+        "write" => t.write_collections,
+        "allowImplicit" => t.allow_implicit
+      })
 
     body =
-      %{collections: collections, action: t.action}
-      |> Map.merge(if t.params, do: %{"params" => t.params}, else: %{})
-      |> Map.merge(if t.lock_timeout, do: %{"lockTimeout" => t.lock_timeout}, else: %{})
-      |> Map.merge(if t.wait_for_sync, do: %{"waitForSync" => t.wait_for_sync}, else: %{})
+      Utils.compact(%{
+        :collections => collections,
+        :action => t.action,
+        "params" => t.params,
+        "lockTimeout" => t.lock_timeout,
+        "waitForSync" => t.wait_for_sync
+      })
 
     request(
       method: :post,

--- a/lib/arango/utils.ex
+++ b/lib/arango/utils.ex
@@ -1,6 +1,13 @@
 defmodule Arango.Utils do
   @moduledoc false
 
+  @doc """
+  Drops keys whose value is `nil`, returning a map safe to send as a
+  request body. Explicit `false` is kept — omit a boolean only by passing `nil`.
+  """
+  @spec compact(map) :: map
+  def compact(map), do: Map.reject(map, fn {_k, v} -> is_nil(v) end)
+
   @spec opts_to_headers(keyword, [atom]) :: keyword
   def opts_to_headers(opts, permitted \\ []) do
     opts

--- a/test/arango/aql_test.exs
+++ b/test/arango/aql_test.exs
@@ -222,17 +222,27 @@ end
     }} = Aql.query_properties() |> on_db(ctx)
   end
 
-  @tag :skip
   test "Changes the properties for the AQL query tracking", ctx do
-    assert {
-      :ok, %{
-        "enabled" => false,
-        "trackSlowQueries" => false,
-        "maxSlowQueries" => 128,
-        "slowQueryThreshold" => 20,
-        "maxQueryStringLength" => 2048,
-      }
-    } == Aql.set_query_properties(enabled: false, track_slow_queries: false, max_slow_queries: 128, slow_query_threshold: 20, max_query_string_length: 2048) |> on_db(ctx)
+    {:ok, _} =
+      Aql.set_query_properties(
+        track_slow_queries: true,
+        max_slow_queries: 128,
+        slow_query_threshold: 20,
+        max_query_string_length: 2048
+      )
+      |> on_db(ctx)
+
+    assert {:ok, %{
+      "trackSlowQueries" => true,
+      "maxSlowQueries" => 128,
+      "slowQueryThreshold" => 20,
+      "maxQueryStringLength" => 2048
+    }} = Aql.query_properties() |> on_db(ctx)
+  end
+
+  test "set_query_properties transmits enabled: false (regression: false must not be dropped)", ctx do
+    {:ok, _} = Aql.set_query_properties(enabled: false) |> on_db(ctx)
+    assert {:ok, %{"enabled" => false}} = Aql.query_properties() |> on_db(ctx)
   end
 
   test "Clears the list of slow AQL queries", ctx do


### PR DESCRIPTION
## Summary

Investigated the nil-vs-false question against the ArangoDB OpenAPI v0 spec and the python-arango reference driver before touching code (see commit body). Verdict: nil-reject is correct everywhere, and it **fixes two latent bugs** rather than introducing risk.

- Add `Utils.compact/1` — drops `nil`, keeps explicit `false` — and use it for body assembly in `cursor_create`, `transaction`, `explain_query`, `set_query_cache_properties`, `set_query_properties`. Collapses ~25 `Map.merge(if x, do: %{k=>x}, else: %{})` lines.
- **Bug 1 (casing):** `set_query_properties` sent `slowQuerythreshold`, `maxSlowqueries`, `trackSlowqueries`, `maxQuerystringlength` — none match the spec, so ArangoDB silently ignored them and the options never applied. Corrected casing.
- **Bug 2 (falsy-drop):** boolean opts set to `false` were dropped by the truthy `if x` guard, so `set_query_properties(enabled: false)` was a no-op. `compact` keeps `false`, matching python-arango's `is not None` semantics.
- `transaction`'s `allowImplicit` special-case (`if == false`) folds into `compact`: `nil` omits (server default `true`), `true`/`false` sent as given — same behavior, no special case.

Why this is safe for the other booleans: in Elixir only `nil`/`false` are falsy, so `if x` and `compact` differ **only** when `x` is `false`; and for `count`/`fullCount`/`waitForSync`/`allPlans` the server default is already `false`, so omit ≡ send-false.

**Stacked on #5** (`ijcd/hygiene-cleanup`) — it shares `aql.ex`/`cursor.ex`. Merge #5 first; I'll retarget to `master`.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] TDD: wrote read-back regression tests first, confirmed they fail (read back defaults 64/10/4096; `enabled` stays `true`), then fixed
- [x] `mix test` — 216 pass / 0 fail / 10 skip (un-skipped the query-tracking test, added `enabled: false` regression)
- [ ] Confirm the casing fix matches your ArangoDB version's property names