### PR TITLE
Make request/1 expand to a compile-time struct literal

### DIFF
--- a/lib/arango/api.ex
+++ b/lib/arango/api.ex
@@ -32,19 +32,25 @@ defmodule Arango.API do
   @doc """
   Build an `%Arango.Request{}` with the module's `@endpoint` pre-filled.
 
-  Accepts any `Arango.Request` field. Use `:method` as shorthand for
-  `:http_method`.
+  Expands at compile time to a struct literal so unknown field names fail
+  to compile (typo-hider gone). Accepts any `Arango.Request` field. Use
+  `:method` as shorthand for `:http_method`.
   """
   defmacro request(opts) do
-    quote do
-      Arango.API.__build__(@endpoint, unquote(opts))
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError,
+            "request/1 requires a literal keyword list, got: #{Macro.to_string(opts)}"
     end
-  end
 
-  @doc false
-  def __build__(endpoint, opts) do
-    {method, opts} = Keyword.pop(opts, :method)
-    fields = [endpoint: endpoint] ++ if(method, do: [http_method: method], else: []) ++ opts
-    struct(Arango.Request, fields)
+    {method, rest} = Keyword.pop(opts, :method)
+
+    fields =
+      [endpoint: quote(do: @endpoint)] ++
+        if(method, do: [http_method: method], else: []) ++
+        rest
+
+    quote do
+      %Arango.Request{unquote_splicing(fields)}
+    end
   end
 end

--- a/test/arango/api_test.exs
+++ b/test/arango/api_test.exs
@@ -41,4 +41,33 @@ defmodule Arango.APITest do
     assert op.system_only == true
     assert op.encode_body == false
   end
+
+  test "unknown keyword key fails at compile time" do
+    src = """
+    defmodule BadKey do
+      use Arango.API, endpoint: :sample
+      def boom, do: request(method: :get, pathh: "x")
+    end
+    """
+
+    assert_raise KeyError, ~r/key :pathh not found/, fn ->
+      Code.compile_string(src)
+    end
+  end
+
+  test "non-literal opts raises ArgumentError at compile time" do
+    src = """
+    defmodule BadOpts do
+      use Arango.API, endpoint: :sample
+      def boom do
+        opts = [method: :get, path: "x"]
+        request(opts)
+      end
+    end
+    """
+
+    assert_raise ArgumentError, ~r/request\/1 requires a literal keyword list/, fn ->
+      Code.compile_string(src)
+    end
+  end
 end


### PR DESCRIPTION
## Bug

`Arango.API.__build__/2` used `struct/2`, which silently DROPS unknown keys. A typo like `request(method: :get, pathh: "x")` compiled and ran — producing a `Request` with `path: nil` and no error. Typo-hider.

## Fix

Rewrite `Arango.API.request/1` to expand at compile time to a struct literal `%Arango.Request{...}`. The compiler validates every key; unknown keys now fail with `KeyError` at compile time.

Also reject non-literal `opts` (e.g. `request(some_var)`) at compile time with a clear `ArgumentError` naming the offending AST.

`__build__/2` deleted.

## Test plan

- [x] New test: `request(method: :get, pathh: "x")` inside a `use Arango.API` module fails to compile with `KeyError` matching `key :pathh not found`.
- [x] New test: `request(opts)` where `opts` is a variable raises `ArgumentError` matching `request/1 requires a literal keyword list`.
- [x] `mix compile --force --warnings-as-errors` clean.
- [x] `mix test` — 216 → 218 passing, 0 failures, 10 skipped. No call site had a hidden typo (none caught by the new check).