### PR TITLE
Phase 4 (Index): add inverted, TTL, MDI, vector index creators

### DIFF
--- a/lib/arango/index.ex
+++ b/lib/arango/index.ex
@@ -124,6 +124,90 @@ defmodule Arango.Index do
   end
 
   @doc """
+  Create inverted index (ArangoSearch)
+
+  POST /_api/index#inverted
+
+  `fields` is a list of either bare field names (`["foo", "bar"]`) or
+  per-field option maps (`[%{"name" => "foo", "analyzer" => "text_en"}]`).
+  """
+  @spec create_inverted(String.t, [String.t | map], keyword) :: Arango.ok_error(map)
+  def create_inverted(collection_name, fields, opts \\ []) when is_list(fields) do
+    query = Utils.opts_to_query([collection: collection_name], [:collection])
+    body =
+      opts
+      |> Utils.opts_to_vars([
+        :name, :analyzer, :features, :includeAllFields, :searchField,
+        :trackListPositions, :parallelism, :consolidationIntervalMsec,
+        :commitIntervalMsec, :cleanupIntervalStep, :primarySort,
+        :storedValues, :inBackground, :cache, :primaryKeyCache,
+        :optimizeTopK, :writebufferActive, :writebufferIdle,
+        :writebufferSizeMax, :consolidationPolicy
+      ])
+      |> Map.merge(%{"type" => "inverted", "fields" => fields})
+
+    request(method: :post, path: "index/", query: query, body: body)
+  end
+
+  @doc """
+  Create TTL (time-to-live) index
+
+  POST /_api/index#ttl
+
+  `expire_after` is in seconds. Documents whose `field` is more than
+  `expire_after` seconds older than now become eligible for removal.
+  """
+  @spec create_ttl(String.t, String.t, integer, keyword) :: Arango.ok_error(map)
+  def create_ttl(collection_name, field, expire_after, opts \\ []) do
+    query = Utils.opts_to_query([collection: collection_name], [:collection])
+    body =
+      opts
+      |> Utils.opts_to_vars([:name, :inBackground])
+      |> Map.merge(%{"type" => "ttl", "fields" => [field], "expireAfter" => expire_after})
+
+    request(method: :post, path: "index/", query: query, body: body)
+  end
+
+  @doc """
+  Create multi-dimensional index (replaces zkd in 3.12)
+
+  POST /_api/index#mdi
+
+  `field_value_types` is currently only `"double"`.
+  """
+  @spec create_mdi(String.t, [String.t], String.t, keyword) :: Arango.ok_error(map)
+  def create_mdi(collection_name, fields, field_value_types, opts \\ []) when is_list(fields) do
+    query = Utils.opts_to_query([collection: collection_name], [:collection])
+    body =
+      opts
+      |> Utils.opts_to_vars([:name, :unique, :sparse, :storedValues, :inBackground, :estimates, :prefixFields])
+      |> Map.merge(%{"type" => "mdi", "fields" => fields, "fieldValueTypes" => field_value_types})
+
+    request(method: :post, path: "index/", query: query, body: body)
+  end
+
+  @doc """
+  Create vector index
+
+  POST /_api/index#vector
+
+  `params` is a required map; ArangoDB requires `metric` (`"l2"` or
+  `"cosine"`), `dimension` (positive integer), and `nLists` (positive integer).
+  Requires a build with vector index support and sufficient training data
+  in the collection before creation.
+  """
+  @spec create_vector(String.t, String.t, map, keyword) :: Arango.ok_error(map)
+  def create_vector(collection_name, field, params, opts \\ []) do
+    query = Utils.opts_to_query([collection: collection_name], [:collection])
+    body =
+      opts
+      |> Utils.opts_to_vars([:name, :inBackground, :storedValues, :parallelism, :sparse])
+      |> Map.merge(%{"type" => "vector", "fields" => [field], "params" => params})
+
+    request(method: :post, path: "index/", query: query, body: body)
+  end
+
+  @doc """
   Delete index
 
   DELETE /_api/index/{index-handle}

--- a/test/arango/index_test.exs
+++ b/test/arango/index_test.exs
@@ -233,6 +233,80 @@ defmodule IndexTest do
     } = Index.create_skiplist(ctx.coll.name, ["foo", "bar", "bang"], unique: true, sparse: true) |> on_db(ctx)
   end
 
+  test "Create inverted index", ctx do
+    assert {
+      :ok, %{
+        "code" => 201,
+        "error" => false,
+        "type" => "inverted",
+        "id" => _,
+        "isNewlyCreated" => true,
+      }
+    } = Index.create_inverted(ctx.coll.name, ["foo", "bar"]) |> on_db(ctx)
+  end
+
+  test "Create TTL index", ctx do
+    assert {
+      :ok, %{
+        "code" => 201,
+        "error" => false,
+        "type" => "ttl",
+        "fields" => ["createdAt"],
+        "expireAfter" => 3600,
+        "id" => _,
+        "isNewlyCreated" => true,
+      }
+    } = Index.create_ttl(ctx.coll.name, "createdAt", 3600) |> on_db(ctx)
+  end
+
+  test "Create MDI index", ctx do
+    assert {
+      :ok, %{
+        "code" => 201,
+        "error" => false,
+        "type" => "mdi",
+        "fields" => ["x", "y"],
+        "fieldValueTypes" => "double",
+        "id" => _,
+        "isNewlyCreated" => true,
+      }
+    } = Index.create_mdi(ctx.coll.name, ["x", "y"], "double") |> on_db(ctx)
+  end
+
+  @tag :skip
+  # Vector indexes require a build with vector support enabled AND training
+  # data inserted before index creation. Documented for completeness; run
+  # against an enabled deployment to verify.
+  test "Create vector index", ctx do
+    assert {
+      :ok, %{
+        "code" => 201,
+        "error" => false,
+        "type" => "vector",
+        "fields" => ["embedding"],
+        "id" => _,
+        "isNewlyCreated" => true,
+      }
+    } = Index.create_vector(ctx.coll.name, "embedding", %{
+      "metric" => "l2",
+      "dimension" => 4,
+      "nLists" => 1
+    }) |> on_db(ctx)
+  end
+
+  test "indexes/1 lists created custom index types", ctx do
+    {:ok, _} = Index.create_inverted(ctx.coll.name, ["a"]) |> on_db(ctx)
+    {:ok, _} = Index.create_ttl(ctx.coll.name, "t", 60) |> on_db(ctx)
+    {:ok, _} = Index.create_mdi(ctx.coll.name, ["x", "y"], "double") |> on_db(ctx)
+
+    {:ok, %{"indexes" => indexes}} = Index.indexes(ctx.coll.name) |> on_db(ctx)
+    types = Enum.map(indexes, & &1["type"])
+    assert "inverted" in types
+    assert "ttl" in types
+    assert "mdi" in types
+    assert "primary" in types
+  end
+
   test "Delete index", ctx do
     {:ok, %{"id" => id}} = Index.create_fulltext(ctx.coll.name, "foo") |> on_db(ctx)
 


### PR DESCRIPTION
## Summary

First of the Phase 4 sub-PRs per the merged plan (`plans/04-update-existing.md`, section 1). Adds four request builders to `Arango.Index`, one per 3.12 index type the driver was missing:

- **`create_inverted/3`** (ArangoSearch). Fields accept either bare strings (`["foo"]`) or per-field option maps (`[%{"name" => "foo", "analyzer" => "text_en"}]`). Allowed opts cover the full inverted-index surface from the spec (name, analyzer, features, includeAllFields, primarySort, storedValues, consolidation/commit/cleanup intervals, parallelism, cache flags, optimizeTopK, writebuffer*).
- **`create_ttl/4`** — single-field TTL, `expireAfter` in seconds.
- **`create_mdi/4`** — multi-dimensional, replaces zkd in 3.12; `field_value_types` arg (`"double"` is the only server-supported value today).
- **`create_vector/4`** — vector embedding index; `params` is the required map (`metric`, `dimension`, `nLists`).

Field lists and allowed-opt sets derived from `POST /_api/index#inverted|#ttl|#mdi|#vector` in the ArangoDB OpenAPI v0 spec.

`create_hash/3` and `create_skiplist/3` keep their Phase 3 `@deprecated` markers — 3.12 still accepts them (server rewrites to persistent); removal waits for v1/4.0.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] TDD: failing tests written first (functions undefined → 4 failures), then implemented to green
- [x] `mix test` — 223 pass / 0 fail / 11 skip (+5 vs prior baseline 218/0/10: 4 new green + 1 new skip)
- [x] `indexes/1` listing test confirms inverted/ttl/mdi appear alongside primary
- [ ] Vector test is `@tag :skip` — requires a build with vector support and training data; documented in the test