### PR TITLE
Phase 4 (Cursor): POST next-batch, retry-fetch, stream/allowRetry/ttl

### DIFF
--- a/lib/arango/cursor.ex
+++ b/lib/arango/cursor.ex
@@ -20,6 +20,8 @@ defmodule Arango.Cursor do
       :satellite_sync_wait,
       :full_count,
       :max_plans,
+      :allow_retry,
+      :stream,
     ]
 
     @type t :: %__MODULE__{
@@ -103,6 +105,16 @@ defmodule Arango.Cursor do
       # maxPlans: Limits the maximum number of plans that are created
       # by the AQL query optimizer.
       max_plans: pos_integer,
+
+      # allow_retry: enables the server to keep each returned batch
+      # around so a client can re-request it via cursor_next_batch/2 if
+      # the previous response was lost in transit.
+      allow_retry: boolean,
+
+      # stream: execute the query in streaming mode. Results are
+      # produced lazily and not fully materialized server-side; useful
+      # for large result sets.
+      stream: boolean,
     }
   end
 
@@ -113,37 +125,30 @@ defmodule Arango.Cursor do
   """
   @spec cursor_create(Cursor.t) :: Arango.ok_error(map)
   def cursor_create(cursor) do
-    query = Map.get(cursor, :query)
-    bind_vars = Map.get(cursor, :bind_vars)
-    count = Map.get(cursor, :count)
-    batch_size = Map.get(cursor, :batch_size)
-    full_count = Map.get(cursor, :full_count)
-    max_plans = Map.get(cursor, :max_plans)
     optimizer_rules = Map.get(cursor, :optimizer_rules)
 
     top_level =
       Utils.compact(%{
-        "query" => query,
-        "bindVars" => bind_vars && Enum.into(bind_vars, %{}),
-        "count" => count,
-        "batchSize" => batch_size
+        "query" => Map.get(cursor, :query),
+        "bindVars" => Map.get(cursor, :bind_vars) && Enum.into(Map.get(cursor, :bind_vars), %{}),
+        "count" => Map.get(cursor, :count),
+        "batchSize" => Map.get(cursor, :batch_size),
+        "ttl" => Map.get(cursor, :ttl)
       })
 
     options =
       Utils.compact(%{
-        "fullCount" => full_count,
-        "maxPlans" => max_plans,
+        "fullCount" => Map.get(cursor, :full_count),
+        "maxPlans" => Map.get(cursor, :max_plans),
+        "allowRetry" => Map.get(cursor, :allow_retry),
+        "stream" => Map.get(cursor, :stream),
         "optimizer" => optimizer_rules && %{"rules" => optimizer_rules}
       })
 
     cursor_request =
       if map_size(options) > 0, do: Map.put(top_level, "options", options), else: top_level
 
-    request(
-      method: :post,
-      path: "cursor",
-      body: cursor_request
-    )
+    request(method: :post, path: "cursor", body: cursor_request)
   end
 
   @doc """
@@ -162,13 +167,27 @@ defmodule Arango.Cursor do
   @doc """
   Read next batch from cursor
 
-  PUT /_api/cursor/{cursor-identifier}
+  POST /_api/cursor/{cursor-identifier}
+
+  3.12 documents POST as the form going forward; PUT is still accepted on
+  v0 but will be dropped in v1/4.0.
   """
-  @spec cursor_next(Cursor.t) :: Arango.ok_error(map)
+  @spec cursor_next(String.t) :: Arango.ok_error(map)
   def cursor_next(cursor_id) do
-    request(
-      method: :put,
-      path: "cursor/#{cursor_id}"
-    )
+    request(method: :post, path: "cursor/#{cursor_id}")
+  end
+
+  @doc """
+  Re-fetch a specific batch from a cursor created with `allow_retry: true`.
+
+  POST /_api/cursor/{cursor-identifier}/{batch-identifier}
+
+  Use the `nextBatchId` returned in a prior cursor response as the
+  `batch_id`. The server retains the batch so a client that lost the
+  previous response in transit can request it again.
+  """
+  @spec cursor_next_batch(String.t, String.t) :: Arango.ok_error(map)
+  def cursor_next_batch(cursor_id, batch_id) do
+    request(method: :post, path: "cursor/#{cursor_id}/#{batch_id}")
   end
 end

--- a/test/arango/cursor_test.exs
+++ b/test/arango/cursor_test.exs
@@ -266,6 +266,44 @@ defmodule CursorTest do
     } = Cursor.cursor_delete(id) |> on_db(ctx)
   end
 
+  test "cursor_next/1 uses POST (3.12 documented form)" do
+    op = Cursor.cursor_next("abc123")
+    assert op.http_method == :post
+    assert op.path == "cursor/abc123"
+  end
+
+  test "cursor_create wires ttl at the top level" do
+    op = Cursor.cursor_create(%Cursor.Cursor{query: "RETURN 1", ttl: 60})
+    assert op.body["ttl"] == 60
+  end
+
+  test "cursor_create wires stream into options" do
+    op = Cursor.cursor_create(%Cursor.Cursor{query: "RETURN 1", stream: true})
+    assert op.body["options"]["stream"] == true
+  end
+
+  test "cursor_create wires allow_retry into options as allowRetry" do
+    op = Cursor.cursor_create(%Cursor.Cursor{query: "RETURN 1", allow_retry: true})
+    assert op.body["options"]["allowRetry"] == true
+  end
+
+  test "cursor_next_batch/2 re-fetches a batch when allowRetry is set", ctx do
+    cursor = %Cursor.Cursor{
+      query: "FOR p IN products SORT p.age RETURN p",
+      batch_size: 2,
+      allow_retry: true
+    }
+
+    {:ok, %{"id" => id, "nextBatchId" => next_id}} =
+      Cursor.cursor_create(cursor) |> on_db(ctx)
+
+    {:ok, b1} = Cursor.cursor_next_batch(id, next_id) |> on_db(ctx)
+    {:ok, b2} = Cursor.cursor_next_batch(id, next_id) |> on_db(ctx)
+
+    assert length(b1["result"]) == 2
+    assert b1["result"] == b2["result"]
+  end
+
   test "Read next batch from cursor", ctx do
     cursor = %Cursor.Cursor{
       query: "FOR p IN products LIMIT 5 RETURN p",


### PR DESCRIPTION
## Summary

Second of the Phase 4 sub-PRs per `plans/04-update-existing.md` (section 2). Three changes to `Arango.Cursor`:

- **`cursor_next/1`**: flip `PUT`→`POST`. 3.12 still accepts PUT on v0 but POST is the documented form and v1/4.0 drops PUT. Went with the plan's proposed default (in-place flip) — easy to revert. No callers had to change; existing test stays green.
- **`cursor_next_batch/2`** (new): `POST /_api/cursor/{cid}/{bid}`. Re-fetches a specific batch using the `nextBatchId` from a prior response. Valid only when the cursor was created with `allow_retry: true`. This is the retry-fetch endpoint that lets clients recover from in-transit batch loss; it's also the building block Phase 5 stream transactions will reuse.
- **`cursor_create/1`**: extended `Cursor` struct with `:allow_retry` and `:stream` (both go in the `options` sub-object as `allowRetry`/`stream`); wired `:ttl` (already on the struct but silently dropped) into the top-level body.

Intentionally left for a future PR: `:cache`, `:memory_limit`, `:profile`, `:satellite_sync_wait` remain on the struct but unwired — separate concern, not in the Phase 4 cursor scope (the plan only named ttl/allow_retry/stream).

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] TDD: pure body-shape tests for `ttl`/`stream`/`allowRetry` fail to compile (caught by the compile-time struct check from #7 — proves the new safety net works) → add struct fields → green
- [x] Integration: `cursor_next_batch` with `allow_retry: true` returns the same payload when called twice with the same batch id
- [x] `mix test` — 228 pass / 0 fail / 11 skip (+5 vs prior baseline 223/0/11: 4 new pure tests + 1 new integration)