### PR TITLE
Phase 4 (Administration): 12 new endpoints + text/plain decoding

### DIFF
--- a/lib/arango/administration.ex
+++ b/lib/arango/administration.ex
@@ -191,4 +191,144 @@ defmodule Arango.Administration do
       path: "version"
     )
   end
+
+  @doc """
+  Return the storage engine info (e.g. `name: "rocksdb"`).
+
+  GET /_api/engine
+  """
+  @spec engine() :: Arango.ok_error(map)
+  def engine() do
+    request(method: :get, system_only: true, path: "engine")
+  end
+
+  @doc """
+  Return engine-internal counters.
+
+  GET /_api/engine/stats
+  """
+  @spec engine_stats() :: Arango.ok_error(map)
+  def engine_stats() do
+    request(method: :get, system_only: true, path: "engine/stats")
+  end
+
+  @doc """
+  Return Prometheus-formatted server metrics.
+
+  GET /_admin/metrics/v2
+
+  Replaces `statistics/0` and `statistics_description/0` in v1/4.0. The
+  response is `text/plain`, so the body comes through the request layer
+  as a raw string — no `ok_decoder` needed.
+  """
+  @spec metrics() :: Arango.ok_error(String.t)
+  def metrics() do
+    request(method: :get, path: "/_admin/metrics/v2")
+  end
+
+  @doc """
+  Return server boot / process status.
+
+  GET /_admin/status
+  """
+  @spec status() :: Arango.ok_error(map)
+  def status() do
+    request(method: :get, path: "/_admin/status")
+  end
+
+  @doc """
+  Return current server mode (`"default"` or `"readonly"`).
+
+  GET /_admin/server/mode
+  """
+  @spec mode() :: Arango.ok_error(map)
+  def mode() do
+    request(method: :get, path: "/_admin/server/mode")
+  end
+
+  @doc """
+  Set the server mode.
+
+  PUT /_admin/server/mode
+
+  `mode_value` is `"default"` or `"readonly"`.
+  """
+  @spec set_mode(String.t) :: Arango.ok_error(map)
+  def set_mode(mode_value) do
+    request(method: :put, path: "/_admin/server/mode", body: %{mode: mode_value})
+  end
+
+  @doc """
+  Return whether the server is ready to serve requests.
+
+  GET /_admin/server/availability
+  """
+  @spec availability() :: Arango.ok_error(map)
+  def availability() do
+    request(method: :get, path: "/_admin/server/availability")
+  end
+
+  @doc """
+  Return a diagnostics bundle.
+
+  GET /_admin/support-info
+  """
+  @spec support_info() :: Arango.ok_error(map)
+  def support_info() do
+    request(method: :get, path: "/_admin/support-info")
+  end
+
+  @doc """
+  Return per-topic log levels.
+
+  GET /_admin/log/level
+  """
+  @spec log_level() :: Arango.ok_error(map)
+  def log_level() do
+    request(method: :get, path: "/_admin/log/level")
+  end
+
+  @doc """
+  Set per-topic log levels.
+
+  PUT /_admin/log/level
+
+  `levels` is a map of topic → level, e.g. `%{"agency" => "DEBUG"}`.
+  """
+  @spec set_log_level(map) :: Arango.ok_error(map)
+  def set_log_level(levels) do
+    request(method: :put, path: "/_admin/log/level", body: levels)
+  end
+
+  @doc """
+  Return structured log entries.
+
+  GET /_admin/log/entries
+
+  Same filtering options as `log/1` but returns a `messages` array of
+  per-entry maps instead of the legacy parallel-arrays shape.
+  """
+  @spec log_entries(keyword) :: Arango.ok_error(map)
+  def log_entries(opts \\ []) do
+    query = Utils.opts_to_query(opts, [:upto, :level, :start, :size, :offset, :search, :sort])
+    request(method: :get, path: "/_admin/log/entries", query: query)
+  end
+
+  @doc """
+  Compact the database.
+
+  PUT /_admin/compact
+
+  Options: `:changeLevel` (boolean), `:compactBottomMostLevel` (boolean).
+  """
+  @spec compact(keyword) :: Arango.ok_error(map)
+  def compact(opts \\ []) do
+    body =
+      Utils.compact(%{
+        "changeLevel" => Keyword.get(opts, :changeLevel),
+        "compactBottomMostLevel" => Keyword.get(opts, :compactBottomMostLevel)
+      })
+
+    request(method: :put, path: "/_admin/compact", body: body)
+  end
 end

--- a/lib/arango/request.ex
+++ b/lib/arango/request.ex
@@ -155,6 +155,15 @@ defmodule Arango.Request do
   defp sanitize_for_json(%{__struct__: _} = struct), do: struct |> Map.from_struct() |> Map.reject(fn {_k, v} -> is_nil(v) end)
   defp sanitize_for_json(other), do: other
 
+  defp text_content_type?(headers) do
+    Enum.any?(headers, fn
+      {k, v} when is_binary(k) and is_binary(v) ->
+        String.downcase(k) == "content-type" and String.starts_with?(v, "text/")
+      _ ->
+        false
+    end)
+  end
+
   defp decode_headers(headers) do
     case List.keyfind(headers, "etag", 0) do
       {"etag", etag} ->
@@ -175,10 +184,14 @@ defmodule Arango.Request do
   defp decode_adapter_response(response) do
     case response do
       {:ok, %ApiConn.Response{status: status, headers: headers, body: body}} when status >= 200 and status < 300 ->
-        try do
-          {:ok, Jason.decode!(body)}
-        rescue
-          _ -> {:ok, decode_headers(headers)}
+        if text_content_type?(headers) do
+          {:ok, body}
+        else
+          try do
+            {:ok, Jason.decode!(body)}
+          rescue
+            _ -> {:ok, decode_headers(headers)}
+          end
         end
       {:ok, %ApiConn.Response{status: status, headers: headers, body: body}}  ->
         try do

--- a/test/arango/administration_test.exs
+++ b/test/arango/administration_test.exs
@@ -254,4 +254,76 @@ defmodule AdministrationTest do
       :ok, %{"server" => "arango", "version" => _}
     } = Administration.version() |> arango()
   end
+
+  # === Phase 4 additions ===
+
+  test "engine/0 returns the storage engine name" do
+    assert {:ok, %{"name" => "rocksdb"}} = Administration.engine() |> arango()
+  end
+
+  test "engine_stats/0 returns a counter map" do
+    assert {:ok, map} = Administration.engine_stats() |> arango()
+    assert is_map(map)
+    assert map_size(map) > 0
+  end
+
+  test "metrics/0 returns Prometheus text (text/plain decoded as raw string)" do
+    assert {:ok, body} = Administration.metrics() |> arango()
+    assert is_binary(body)
+    assert String.contains?(body, "arangodb_")
+  end
+
+  test "status/0 reports server info" do
+    assert {:ok, %{"serverInfo" => server_info}} = Administration.status() |> arango()
+    assert is_map(server_info)
+  end
+
+  test "mode/0 returns default in a fresh container" do
+    assert {:ok, %{"mode" => "default"}} = Administration.mode() |> arango()
+  end
+
+  test "availability/0 returns ok when the server is ready" do
+    assert {:ok, _} = Administration.availability() |> arango()
+  end
+
+  test "support_info/0 returns a diagnostics bundle" do
+    assert {:ok, info} = Administration.support_info() |> arango()
+    assert is_map(info)
+  end
+
+  test "log_level/0 returns a topic-keyed map" do
+    assert {:ok, levels} = Administration.log_level() |> arango()
+    assert is_map(levels)
+    assert map_size(levels) > 0
+  end
+
+  test "log_entries/1 returns structured entries" do
+    assert {:ok, %{"messages" => messages}} = Administration.log_entries() |> arango()
+    assert is_list(messages)
+  end
+
+  @tag :skip
+  # /_admin/compact requires JWT-authenticated *superuser*; basic-auth root
+  # gets 403 "compaction is only allowed for superusers". Run against a JWT
+  # session to verify.
+  test "compact/1 succeeds on a fresh database" do
+    assert {:ok, _} = Administration.compact() |> arango()
+  end
+
+  # Pure body-shape tests for state-changing endpoints (avoid touching
+  # server-wide settings during the integration suite).
+
+  test "set_mode/1 builds a PUT with mode in the body" do
+    op = Administration.set_mode("readonly")
+    assert op.http_method == :put
+    assert op.body == %{mode: "readonly"}
+    assert op.path == "/_admin/server/mode"
+  end
+
+  test "set_log_level/1 builds a PUT with the topic map as the body" do
+    op = Administration.set_log_level(%{"agency" => "DEBUG"})
+    assert op.http_method == :put
+    assert op.body == %{"agency" => "DEBUG"}
+    assert op.path == "/_admin/log/level"
+  end
 end


### PR DESCRIPTION
## Summary

Third Phase 4 sub-PR per `plans/04-update-existing.md` (section 3). Adds the storage-engine, metrics, status, mode, availability, support-info, log-level, and compaction endpoints that landed since the driver was written.

| Function | Method | Path | Notes |
|---|---|---|---|
| `engine/0` | GET | `/_api/engine` | storage engine info |
| `engine_stats/0` | GET | `/_api/engine/stats` | engine counters |
| `metrics/0` | GET | `/_admin/metrics/v2` | **Prometheus text format** |
| `status/0` | GET | `/_admin/status` | server boot/process state |
| `mode/0` / `set_mode/1` | GET/PUT | `/_admin/server/mode` | `default` vs `readonly` |
| `availability/0` | GET | `/_admin/server/availability` | readiness probe |
| `support_info/0` | GET | `/_admin/support-info` | diagnostics bundle |
| `log_level/0` / `set_log_level/1` | GET/PUT | `/_admin/log/level` | per-topic levels |
| `log_entries/1` | GET | `/_admin/log/entries` | structured replacement for `log/1` |
| `compact/1` | PUT | `/_admin/compact` | superuser-gated |

`metrics/0` retires `statistics/0` and `statistics_description/0` (which are `@deprecated` from Phase 3).

### One Request-layer change: `text/plain` handling

`metrics/0` returns Prometheus exposition (`text/plain`), not JSON. The prior `decode_adapter_response/1` would hit `Jason.decode!`, fall through the rescue, and *silently return the response headers* instead of the body. Going with the plan's proposed default — sniff `Content-Type`; for `text/*` return the body raw. JSON paths unchanged. Closes one of the three open questions from the plan.

### Test choices

- Integration tests for the read-only and read-mostly endpoints.
- `set_mode/1` and `set_log_level/1`: **pure body-shape tests only** — these mutate *server-global* state and would interfere with the rest of the (sync) suite if integration-tested. Pure assertions cover the function contract.
- `compact/1`: `@tag :skip` with a note. Basic-auth root gets `403 "compaction is only allowed for superusers"` — needs a JWT-authenticated superuser session to verify. Same pattern as the vector index test.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] TDD: tests written first, confirmed failing for the right reasons (undefined functions, then `metrics/0` returning headers instead of body — fixed by the text/plain branch)
- [x] `mix test` — 240 pass / 0 fail / 12 skip (+12 vs prior baseline 228/0/11: 11 new green + 1 new skip)