### PR TITLE
Phase 4 (Document): thread refillIndexCaches + versionAttribute options

### DIFF
--- a/lib/arango/document.ex
+++ b/lib/arango/document.ex
@@ -25,7 +25,7 @@ defmodule Arango.Document do
   """
   @spec create(Collection.t, map | [map]) :: Arango.ok_error(map | [map])
   def create(collection, document, opts \\ []) do
-    query = Utils.opts_to_query(opts, [:waitForSync, :returnNew])
+    query = Utils.opts_to_query(opts, [:waitForSync, :returnNew, :refillIndexCaches, :versionAttribute])
 
     request(
       method: :post,
@@ -100,7 +100,7 @@ defmodule Arango.Document do
 
   @spec update(Collection.t, [map], keyword) :: Arango.ok_error([map])
   def update(collection, new_docs, opts) when is_list(new_docs) do
-    query = Utils.opts_to_query(opts, [:keepNull, :mergeObjects, :waitForSync, :ignoreRevs, :returnOld, :returnNew])
+    query = Utils.opts_to_query(opts, [:keepNull, :mergeObjects, :waitForSync, :ignoreRevs, :returnOld, :returnNew, :refillIndexCaches, :versionAttribute])
 
     request(
       method: :patch,
@@ -115,7 +115,7 @@ defmodule Arango.Document do
   def update(document, new_document, opts) do
     {header_opts, query_opts} = Keyword.split(opts, [:ifMatch])
     headers = Utils.opts_to_headers(header_opts, [:ifMatch])
-    query = Utils.opts_to_query(query_opts, [:keepNull, :mergeObjects, :waitForSync, :ignoreRevs, :returnOld, :returnNew])
+    query = Utils.opts_to_query(query_opts, [:keepNull, :mergeObjects, :waitForSync, :ignoreRevs, :returnOld, :returnNew, :refillIndexCaches, :versionAttribute])
 
     request(
       method: :patch,
@@ -136,7 +136,7 @@ defmodule Arango.Document do
 
   @spec replace(Collection.t, [map], keyword) :: Arango.ok_error([map])
   def replace(collection, new_docs, opts) when is_list(new_docs) do
-    query = Utils.opts_to_query(opts, [:keepNull, :mergeObjects, :waitForSync, :ignoreRevs, :returnOld, :returnNew])
+    query = Utils.opts_to_query(opts, [:keepNull, :mergeObjects, :waitForSync, :ignoreRevs, :returnOld, :returnNew, :refillIndexCaches, :versionAttribute])
 
     request(
       method: :put,
@@ -151,7 +151,7 @@ defmodule Arango.Document do
   def replace(document, new_document, opts) do
     {header_opts, query_opts} = Keyword.split(opts, [:ifMatch])
     headers = Utils.opts_to_headers(header_opts, [:ifMatch])
-    query = Utils.opts_to_query(query_opts, [:keepNull, :mergeObjects, :waitForSync, :ignoreRevs, :returnOld, :returnNew])
+    query = Utils.opts_to_query(query_opts, [:keepNull, :mergeObjects, :waitForSync, :ignoreRevs, :returnOld, :returnNew, :refillIndexCaches, :versionAttribute])
 
     request(
       method: :put,

--- a/test/arango/document_test.exs
+++ b/test/arango/document_test.exs
@@ -938,4 +938,39 @@ defmodule DocumentTest do
       assert {:ok, _} = Document.document(dref3) |> on_db(ctx)
     end
   end
+
+  describe "Phase 4 option additions" do
+    test "create/3 accepts refillIndexCaches", ctx do
+      assert {:ok, _} =
+               Document.create(ctx.coll, %{"x" => 1}, refillIndexCaches: true)
+               |> on_db(ctx)
+    end
+
+    test "create/3 (multi) accepts refillIndexCaches", ctx do
+      assert [{:ok, _}, {:ok, _}] =
+               Document.create(
+                 ctx.coll,
+                 [%{"x" => 1}, %{"x" => 2}],
+                 refillIndexCaches: true
+               )
+               |> on_db(ctx)
+    end
+
+    test "update/3 with versionAttribute skips when the incoming version is not newer", ctx do
+      {:ok, dref} = Document.create(ctx.coll, %{"v" => 1, "data" => "first"}) |> on_db(ctx)
+
+      # v 1 -> 2 succeeds; stored version becomes 2.
+      {:ok, _} =
+        Document.update(dref, %{"v" => 2, "data" => "second"}, versionAttribute: "v")
+        |> on_db(ctx)
+
+      # Stale attempt: incoming v=1 is not greater than stored v=2 -> server skips.
+      Document.update(dref, %{"v" => 1, "data" => "stale"}, versionAttribute: "v")
+      |> on_db(ctx)
+
+      {:ok, current} = Document.document(dref) |> on_db(ctx)
+      assert current["v"] == 2
+      assert current["data"] == "second"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fourth Phase 4 sub-PR per `plans/04-update-existing.md` (section 4). Small one — pure allowlist extension on the five `Utils.opts_to_query/2` sites in `document.ex`:

- `create/3` (single + multi via list)
- `update/3` (single + multi)
- `replace/3` (single + multi)

Two new query params land everywhere:

- **`refillIndexCaches`** (boolean): repopulate index caches after the write.
- **`versionAttribute`** (string): optimistic concurrency by external version field. Server **skips** the update when the incoming version is not strictly greater than the stored one (it doesn't return 412 — the plan's note on that was slightly off; the test asserts the stored doc is unchanged, which is robust to either outcome).

No new functions, no signature changes.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] TDD: tests written first — failed with `(RuntimeError) unknown key: refillIndexCaches` from `Utils.ensure_permitted`, exactly the right red signal
- [x] `mix test` — 243 pass / 0 fail / 12 skip (+3 vs prior baseline 240/0/12)
- [x] versionAttribute skip-semantics test verifies: insert v=1, bump to v=2, attempt v=1 → stored doc still v=2/"second"