### PR TITLE
Phase 4 (Collection): schema/computedValues/cacheEnabled + 3 endpoints

### DIFF
--- a/lib/arango/collection.ex
+++ b/lib/arango/collection.ex
@@ -17,6 +17,9 @@ defmodule Arango.Collection do
     isSystem: false,
     type: 2,
     indexBuckets: 16,
+    schema: nil,
+    computedValues: nil,
+    cacheEnabled: nil,
   ]
   use ExConstructor
 
@@ -39,6 +42,9 @@ defmodule Arango.Collection do
     isSystem: nil | boolean,
     type: nil | 2 | 3,
     indexBuckets: nil | pos_integer(),
+    schema: nil | map,
+    computedValues: nil | [map],
+    cacheEnabled: nil | boolean,
   }
 
   @doc """
@@ -151,7 +157,14 @@ defmodule Arango.Collection do
   """
   @spec set_properties(t, keyword) :: Arango.ok_error(map)
   def set_properties(collection, opts \\ []) do
-    properties = Utils.opts_to_vars(opts, [:waitForSync, :journalSize])
+    properties =
+      Utils.opts_to_vars(opts, [
+        :waitForSync,
+        :journalSize,
+        :cacheEnabled,
+        :schema,
+        :computedValues
+      ])
 
     request(
       method: :put,
@@ -198,6 +211,41 @@ defmodule Arango.Collection do
   @spec truncate(t) :: Arango.ok_error(map)
   def truncate(collection) do
     request(method: :put, path: "collection/#{collection.name}/truncate")
+  end
+
+  @doc """
+  Compact a collection (3.12)
+
+  PUT /_api/collection/{collection-name}/compact
+  """
+  @spec compact(t) :: Arango.ok_error(map)
+  def compact(collection) do
+    request(method: :put, path: "collection/#{collection.name}/compact")
+  end
+
+  @doc """
+  Return shards for a collection (cluster mode only).
+
+  GET /_api/collection/{collection-name}/shards
+
+  Returns 400 on single-server deployments.
+  """
+  @spec shards(t) :: Arango.ok_error(map)
+  def shards(collection) do
+    request(method: :get, path: "collection/#{collection.name}/shards")
+  end
+
+  @doc """
+  Return the shard responsible for a document (cluster mode only).
+
+  PUT /_api/collection/{collection-name}/responsibleShard
+
+  `document` must include the collection's shard-key fields. Returns
+  400 on single-server deployments.
+  """
+  @spec responsible_shard(t, map) :: Arango.ok_error(map)
+  def responsible_shard(collection, document) do
+    request(method: :put, path: "collection/#{collection.name}/responsibleShard", body: document)
   end
 
   defmodule CollectionDecoder do

--- a/test/arango/collection_test.exs
+++ b/test/arango/collection_test.exs
@@ -148,4 +148,75 @@ defmodule CollectionTest do
 
     assert %{"name" => ^coll_name, "error" => false} = truncate
   end
+
+  # === Phase 4 additions ===
+
+  test "create/2 with schema rejects invalid documents", ctx do
+    schema = %{
+      "rule" => %{
+        "type" => "object",
+        "properties" => %{"name" => %{"type" => "string"}},
+        "required" => ["name"]
+      },
+      "level" => "strict",
+      "message" => "name is required"
+    }
+
+    {:ok, _} =
+      Collection.create(%Collection{name: "validated", schema: schema}) |> on_db(ctx)
+
+    c = %Collection{name: "validated"}
+    {:ok, _} = Document.create(c, %{"name" => "Alice"}) |> on_db(ctx)
+    assert {:error, %{"code" => 400}} = Document.create(c, %{}) |> on_db(ctx)
+  end
+
+  test "create/2 with computedValues echoes the definition in properties", ctx do
+    computed = [
+      %{
+        "name" => "x2",
+        "expression" => "RETURN @doc.x * 2",
+        "computeOn" => ["insert"],
+        "overwrite" => true
+      }
+    ]
+
+    {:ok, _} =
+      Collection.create(%Collection{name: "with_cv", computedValues: computed})
+      |> on_db(ctx)
+
+    {:ok, props} = Collection.properties(%Collection{name: "with_cv"}) |> on_db(ctx)
+    assert is_list(props["computedValues"])
+    assert hd(props["computedValues"])["name"] == "x2"
+  end
+
+  test "create/2 with cacheEnabled echoes the flag in properties", ctx do
+    {:ok, _} =
+      Collection.create(%Collection{name: "cached", cacheEnabled: true}) |> on_db(ctx)
+
+    {:ok, props} = Collection.properties(%Collection{name: "cached"}) |> on_db(ctx)
+    assert props["cacheEnabled"] == true
+  end
+
+  test "set_properties/2 toggles cacheEnabled", ctx do
+    {:ok, _} = Collection.set_properties(ctx.coll, cacheEnabled: true) |> on_db(ctx)
+    {:ok, props} = Collection.properties(ctx.coll) |> on_db(ctx)
+    assert props["cacheEnabled"] == true
+  end
+
+  test "compact/1 succeeds on a populated collection", ctx do
+    for i <- 1..100, do: {:ok, _} = Document.create(ctx.coll, %{"i" => i}) |> on_db(ctx)
+    assert {:ok, _} = Collection.compact(ctx.coll) |> on_db(ctx)
+  end
+
+  @tag :skip
+  # Cluster-only: single-server ArangoDB returns 400. Run against a cluster
+  # deployment to verify.
+  test "shards/1 returns the shard list in cluster mode", ctx do
+    assert {:ok, _} = Collection.shards(ctx.coll) |> on_db(ctx)
+  end
+
+  @tag :skip
+  test "responsible_shard/2 returns the shard id for a document", ctx do
+    assert {:ok, _} = Collection.responsible_shard(ctx.coll, %{"_key" => "any"}) |> on_db(ctx)
+  end
 end


### PR DESCRIPTION
## Summary

Fifth Phase 4 sub-PR per \`plans/04-update-existing.md\` (section 5).

**Struct extension on \`Arango.Collection\`** — three 3.12 fields, default \`nil\` so they're omitted unless set:

- \`:schema\` — JSON Schema validator (rule/level/message). Server enforces it on writes.
- \`:computedValues\` — array of computed-attribute definitions (name/expression/computeOn/overwrite).
- \`:cacheEnabled\` — in-memory document cache toggle.

Both \`create/2\` (struct fields flow through the JSON body) and \`set_properties/2\` (allowlist extended) accept the three.

**Three new endpoints:**

| Function | Method | Path | Notes |
|---|---|---|---|
| \`compact/1\` | PUT | \`/_api/collection/{name}/compact\` | per-collection compaction |
| \`shards/1\` | GET | \`/_api/collection/{name}/shards\` | cluster-only |
| \`responsible_shard/2\` | PUT | \`/_api/collection/{name}/responsibleShard\` | cluster-only |

## Test plan

- [x] \`mix compile --warnings-as-errors\` clean
- [x] TDD red came from the compile-time struct check (#7): \`%Collection{schema: ...}\` failed to compile until the field landed
- [x] \`mix test\` — 250 pass / 0 fail / 14 skip (+7 vs prior 243/0/12: 5 new green + 2 new \`:skip\` for cluster-only)
- [x] Schema validation test confirms server rejects \`%{}\` when \`name\` required (\`errorNum 1620\` / \`code 400\`)
- [x] Cluster endpoints (\`shards/1\`, \`responsible_shard/2\`) tagged \`:skip\` — single-server returns \`400 errorNum 9 "shards API is only available in a cluster"\`; verified the responses are sensible, run against a cluster to fully validate