### PR TITLE
Phase 4 (Database): sharding / replicationFactor / writeConcern options

### DIFF
--- a/lib/arango/database.ex
+++ b/lib/arango/database.ex
@@ -31,11 +31,22 @@ defmodule Arango.Database do
   def create(database \\ [])
   def create(%__MODULE__{name: name}), do: create(name: name)
   def create(opts) do
+    top = opts |> Keyword.take([:name, :users]) |> Enum.into(%{})
+
+    options =
+      Utils.compact(%{
+        "sharding" => Keyword.get(opts, :sharding),
+        "replicationFactor" => Keyword.get(opts, :replicationFactor),
+        "writeConcern" => Keyword.get(opts, :writeConcern)
+      })
+
+    body = if map_size(options) > 0, do: Map.put(top, "options", options), else: top
+
     request(
       method: :post,
       system_only: true,
       path: "database",
-      body: opts |> Keyword.take([:name, :users]) |> Enum.into(%{}),
+      body: body,
       ok_decoder: __MODULE__.PlainDecoder
     )
   end

--- a/lib/arango/database.ex
+++ b/lib/arango/database.ex
@@ -26,7 +26,7 @@ defmodule Arango.Database do
   POST /_api/database
   """
   @type create_database_user_opts :: [{:username, String.t} | {:passwd, String.t} | {:active, boolean} | {:extra, Map.t}]
-  @type create_database_opts :: [{:name, String.t} | {:users, [create_database_user_opts]}]
+  @type create_database_opts :: [{:name, String.t} | {:users, [create_database_user_opts]} | {:sharding, String.t} | {:replicationFactor, pos_integer | String.t} | {:writeConcern, pos_integer}]
   @spec create(create_database_opts) :: Arango.ok_error(any())
   def create(database \\ [])
   def create(%__MODULE__{name: name}), do: create(name: name)

--- a/test/arango/database_test.exs
+++ b/test/arango/database_test.exs
@@ -89,5 +89,30 @@ defmodule DatabaseTest do
     assert is_list(dbs)
     assert "_system" in dbs
     assert new_dbname in dbs
-  end  
+  end
+
+  # === Phase 4 additions ===
+  # Pure body-shape tests: single-server silently ignores these cluster
+  # options, so an integration test would pass even when the option is
+  # being dropped by the wrapper. Assert the request body directly.
+
+  test "create/1 places sharding under the options sub-object" do
+    op = Database.create(name: "x", sharding: "single")
+    assert op.body["options"]["sharding"] == "single"
+  end
+
+  test "create/1 places replicationFactor under the options sub-object" do
+    op = Database.create(name: "x", replicationFactor: 2)
+    assert op.body["options"]["replicationFactor"] == 2
+  end
+
+  test "create/1 places writeConcern under the options sub-object" do
+    op = Database.create(name: "x", writeConcern: 1)
+    assert op.body["options"]["writeConcern"] == 1
+  end
+
+  test "create/1 omits options sub-object when no cluster opts are set" do
+    op = Database.create(name: "x")
+    refute Map.has_key?(op.body, "options")
+  end
 end


### PR DESCRIPTION
## Summary

Sixth Phase 4 sub-PR per \`plans/04-update-existing.md\` (section 6). Small one. Three cluster options on \`Database.create/1\`:

- \`:sharding\` (\`"single"\` | \`"flexible"\`)
- \`:replicationFactor\` (integer or \`"satellite"\`)
- \`:writeConcern\` (integer)

Per the spec, they belong in the body's \`options\` sub-object, not at top level. Compacted out when not set so the common-case wire shape is unchanged.

### Note on test shape

I wrote integration tests first and they **passed without the fix** — single-server silently ignores these cluster options, so the create succeeded whether or not the option reached the server. The prior wrapper was doing \`Keyword.take([:name, :users])\`, silently dropping the new keys, and the test couldn't tell. Switched to **pure body-shape tests** that assert the constructed request body has \`options.sharding == "single"\` etc.; those turned red correctly before the implementation change. Lesson worth flagging: TDD red has to fail for the *right* reason, not just any reason — and "server accepted my request" is a weak signal when the option is server-optional.

## Test plan

- [x] \`mix compile --warnings-as-errors\` clean
- [x] TDD red on pure body-shape: \`options\` key absent → assertion fails with \`left: nil\`
- [x] After fix: body has \`options.sharding\` / \`options.replicationFactor\` / \`options.writeConcern\` as expected
- [x] \`mix test\` — 254 pass / 0 fail / 14 skip (+4 vs prior baseline 250/0/14)
- [x] \`options\` sub-object omitted when no cluster opts are set