### PR TITLE
Phase 4 (AQL): query_rules, clear_plan_cache, plan_cache_entries

### DIFF
--- a/lib/arango/aql.ex
+++ b/lib/arango/aql.ex
@@ -291,4 +291,34 @@ defmodule Arango.Aql do
       path: "query/#{query_id}"
     )
   end
+
+  @doc """
+  List available AQL optimizer rules and their default state.
+
+  GET /_api/query/rules
+  """
+  @spec query_rules() :: Arango.Request.t()
+  def query_rules() do
+    request(method: :get, path: "query/rules")
+  end
+
+  @doc """
+  Clear the AQL query plan cache.
+
+  DELETE /_api/query-plan-cache
+  """
+  @spec clear_plan_cache() :: Arango.Request.t()
+  def clear_plan_cache() do
+    request(method: :delete, path: "query-plan-cache")
+  end
+
+  @doc """
+  List entries in the AQL query plan cache.
+
+  GET /_api/query-plan-cache
+  """
+  @spec plan_cache_entries() :: Arango.Request.t()
+  def plan_cache_entries() do
+    request(method: :get, path: "query-plan-cache")
+  end
 end

--- a/test/arango/aql_test.exs
+++ b/test/arango/aql_test.exs
@@ -323,7 +323,8 @@ defmodule AqlTest do
   end
 
   test "clear_plan_cache/0 succeeds", ctx do
-    assert {:ok, _} = Aql.clear_plan_cache() |> on_db(ctx)
+    assert {:ok, %{"code" => 200, "error" => false}} =
+             Aql.clear_plan_cache() |> on_db(ctx)
   end
 
   test "plan_cache_entries/0 returns a list", ctx do

--- a/test/arango/aql_test.exs
+++ b/test/arango/aql_test.exs
@@ -311,4 +311,23 @@ defmodule AqlTest do
     assert {:error, %{"error" => true, "errorNum" => 1591}} =
              Aql.kill_query("somequery") |> on_db(ctx)
   end
+
+  # === Phase 4 additions ===
+
+  test "query_rules/0 lists optimizer rules", ctx do
+    assert {:ok, rules} = Aql.query_rules() |> on_db(ctx)
+    assert is_list(rules)
+    refute Enum.empty?(rules)
+    assert is_binary(hd(rules)["name"])
+    assert is_map(hd(rules)["flags"])
+  end
+
+  test "clear_plan_cache/0 succeeds", ctx do
+    assert {:ok, _} = Aql.clear_plan_cache() |> on_db(ctx)
+  end
+
+  test "plan_cache_entries/0 returns a list", ctx do
+    assert {:ok, entries} = Aql.plan_cache_entries() |> on_db(ctx)
+    assert is_list(entries)
+  end
 end


### PR DESCRIPTION
## Summary

Seventh Phase 4 sub-PR per \`plans/04-update-existing.md\` (section 7). Three endpoints added in 3.12+:

| Function | Method | Path |
|---|---|---|
| \`query_rules/0\` | GET | \`/_api/query/rules\` |
| \`clear_plan_cache/0\` | DELETE | \`/_api/query-plan-cache\` |
| \`plan_cache_entries/0\` | GET | \`/_api/query-plan-cache\` |

\`query_rules/0\` returns the optimizer rule metadata (each rule has \`name\`, \`flags\`, defaults). The plan-cache pair gives visibility into / control over the new AQL plan cache.

Per the plan, also verified the existing \`slow_queries/0\`, \`clear_slow_queries/0\`, \`kill_query/1\`, \`current_queries/0\`, \`query_properties/0\`, \`set_query_properties/1\` paths still match the 3.12 OpenAPI spec — no code change. AQL user functions (\`functions/0\` etc.) remain \`@deprecated\` from Phase 3.

Note on spec convention: new functions use \`:: Arango.Request.t()\` (the actual immediate return) rather than \`:: Arango.ok_error(...)\` (the eventual response). The systemic mismatch on the other ~80 specs is what \`.dialyzer_ignore.exs\` suppresses; new code is written correctly so the eventual bulk-rewrite PR has less to touch.

## Test plan

- [x] CI gate (\`mix verify\`) clean locally — compile / format / credo / dialyzer all pass
- [x] \`mix test\` — 257 pass / 0 fail / 14 skip (+3 vs prior baseline 254/0/14)
- [x] \`query_rules/0\` returns a non-empty list with \`name\` + \`flags\` per entry
- [x] \`clear_plan_cache/0\` returns ok
- [x] \`plan_cache_entries/0\` returns a list (may be empty when nothing's been queried)