### PR TITLE
Phase 4 (User): collection-level permissions + permission lookups

### DIFF
--- a/lib/arango/user.ex
+++ b/lib/arango/user.ex
@@ -176,6 +176,92 @@ defmodule Arango.User do
     )
   end
 
+  @doc """
+  Grant collection-level access.
+
+  PUT /_api/user/{user}/database/{dbname}/{collection}
+
+  `level` is `"rw" | "ro" | "none"` and defaults to `"rw"` to match
+  `grant/2`. Use `revoke/3` (DELETE) to remove the collection-level
+  override entirely so the user falls back to the database-level grant.
+  """
+  @spec grant(t() | String.t(), String.t(), String.t(), String.t()) :: Arango.Request.t()
+  def grant(user, database_name, collection, level \\ "rw")
+
+  def grant(%__MODULE__{user: user_name}, database_name, collection, level),
+    do: grant(user_name, database_name, collection, level)
+
+  def grant(user_name, database_name, collection, level) when is_binary(user_name) do
+    request(
+      method: :put,
+      system_only: true,
+      path: "user/#{user_name}/database/#{database_name}/#{collection}",
+      body: %{grant: level}
+    )
+  end
+
+  @doc """
+  Revoke a collection-level grant. Removes the override entirely;
+  effective permission falls back to the database-level default.
+
+  DELETE /_api/user/{user}/database/{dbname}/{collection}
+  """
+  @spec revoke(t() | String.t(), String.t(), String.t()) :: Arango.Request.t()
+  def revoke(%__MODULE__{user: user_name}, database_name, collection),
+    do: revoke(user_name, database_name, collection)
+
+  def revoke(user_name, database_name, collection) when is_binary(user_name) do
+    request(
+      method: :delete,
+      system_only: true,
+      path: "user/#{user_name}/database/#{database_name}/#{collection}"
+    )
+  end
+
+  @doc """
+  List a user's database permissions.
+
+  GET /_api/user/{user}/database
+
+  Alias for `databases/1` under the permissions/permission family.
+  """
+  @spec permissions(t() | String.t()) :: Arango.Request.t()
+  def permissions(user), do: databases(user)
+
+  @doc """
+  Effective database-level permission for a user.
+
+  GET /_api/user/{user}/database/{dbname}
+  """
+  @spec permissions(t() | String.t(), String.t()) :: Arango.Request.t()
+  def permissions(%__MODULE__{user: user_name}, database_name),
+    do: permissions(user_name, database_name)
+
+  def permissions(user_name, database_name) when is_binary(user_name) do
+    request(
+      method: :get,
+      system_only: true,
+      path: "user/#{user_name}/database/#{database_name}"
+    )
+  end
+
+  @doc """
+  Effective collection-level permission for a user.
+
+  GET /_api/user/{user}/database/{dbname}/{collection}
+  """
+  @spec permission(t() | String.t(), String.t(), String.t()) :: Arango.Request.t()
+  def permission(%__MODULE__{user: user_name}, database_name, collection),
+    do: permission(user_name, database_name, collection)
+
+  def permission(user_name, database_name, collection) when is_binary(user_name) do
+    request(
+      method: :get,
+      system_only: true,
+      path: "user/#{user_name}/database/#{database_name}/#{collection}"
+    )
+  end
+
   defmodule UserDecoder do
     @moduledoc false
     alias Arango.User

--- a/test/arango/user_test.exs
+++ b/test/arango/user_test.exs
@@ -98,4 +98,63 @@ defmodule UserTest do
     {:ok, dbs} = User.databases(johnny) |> arango()
     assert Map.get(dbs, db_name, "none") == "none"
   end
+
+  # === Phase 4 additions ===
+
+  test "permissions/1 is an alias for databases/1" do
+    {:ok, dbs} = User.permissions(%User{user: "root"}) |> arango()
+    assert is_map(dbs)
+    assert Map.has_key?(dbs, "_system")
+  end
+
+  test "permissions/2 returns the effective database permission", ctx do
+    user = "user_perm_#{System.unique_integer([:positive])}"
+    {:ok, _} = User.create(user: user) |> arango()
+    {:ok, _} = User.grant(user, ctx.db_name) |> arango()
+
+    assert {:ok, %{"result" => "rw"}} =
+             User.permissions(user, ctx.db_name) |> arango()
+  end
+
+  test "grant/4 grants ro on a collection", ctx do
+    user = "user_coll_ro_#{System.unique_integer([:positive])}"
+    {:ok, _} = User.create(user: user) |> arango()
+    {:ok, _} = User.grant(user, ctx.db_name) |> arango()
+    {:ok, _} = User.grant(user, ctx.db_name, ctx.coll.name, "ro") |> arango()
+
+    assert {:ok, %{"result" => "ro"}} =
+             User.permission(user, ctx.db_name, ctx.coll.name) |> arango()
+  end
+
+  test "revoke/3 removes the collection-level grant (db-level remains)", ctx do
+    user = "user_coll_rev_#{System.unique_integer([:positive])}"
+    {:ok, _} = User.create(user: user) |> arango()
+    {:ok, _} = User.grant(user, ctx.db_name) |> arango()
+    # Pin collection to none, distinct from the db-level "rw"
+    {:ok, _} = User.grant(user, ctx.db_name, ctx.coll.name, "none") |> arango()
+
+    assert {:ok, %{"result" => "none"}} =
+             User.permission(user, ctx.db_name, ctx.coll.name) |> arango()
+
+    # Remove the collection-level grant → falls back to db-level default
+    {:ok, _} = User.revoke(user, ctx.db_name, ctx.coll.name) |> arango()
+
+    {:ok, %{"result" => level}} =
+      User.permission(user, ctx.db_name, ctx.coll.name) |> arango()
+
+    # After revoke, the collection-level entry is gone; effective grant
+    # is the db-level "rw" (3.12 returns either the inherited value or
+    # "undefined" depending on server config — accept both).
+    assert level in ["rw", "undefined"]
+  end
+
+  test "permission/3 returns the effective collection grant", ctx do
+    user = "user_coll_eff_#{System.unique_integer([:positive])}"
+    {:ok, _} = User.create(user: user) |> arango()
+    {:ok, _} = User.grant(user, ctx.db_name) |> arango()
+    {:ok, _} = User.grant(user, ctx.db_name, ctx.coll.name, "rw") |> arango()
+
+    assert {:ok, %{"result" => "rw"}} =
+             User.permission(user, ctx.db_name, ctx.coll.name) |> arango()
+  end
 end


### PR DESCRIPTION
## Summary

Eighth Phase 4 sub-PR per \`plans/04-update-existing.md\` (section 8). Adds collection-level grants and the permission-lookup family alongside the existing database-level operations.

| Function | Method | Path | Notes |
|---|---|---|---|
| \`grant/3\`, \`grant/4\` | PUT | \`/_api/user/{u}/database/{db}/{coll}\` | 4-arg explicit level; 3-arg defaults \`"rw"\` |
| \`revoke/3\` | DELETE | \`/_api/user/{u}/database/{db}/{coll}\` | Removes the override; falls back to db-level |
| \`permissions/1\` | GET | \`/_api/user/{u}/database\` | Alias for \`databases/1\` under the permissions naming family |
| \`permissions/2\` | GET | \`/_api/user/{u}/database/{db}\` | Effective database-level permission |
| \`permission/3\` | GET | \`/_api/user/{u}/database/{db}/{coll}\` | Effective collection-level permission |

**Semantic note on the two revokes:** \`revoke/2\` (existing, unchanged) does \`PUT\` with \`%{grant: "none"}\` — an explicit "none" *override* at the database level. \`revoke/3\` (new) does \`DELETE\` — removes the collection-level override so the user inherits the database-level grant. Different operations, matching the 3.12 API's actual semantics.

Existing \`grant/2\`, \`revoke/2\`, \`databases/1\` left unchanged for backward compat.

## Test plan

- [x] \`mix verify\` clean locally (format / compile-w-errors / credo / dialyzer)
- [ ] Integration tests (need ArangoDB) — OrbStack isn't running on this end, deferring to CI. Tests cover: \`permissions/1\` alias, \`permissions/2\` effective db permission, \`grant/4\` granting ro on a collection, \`revoke/3\` falling back to db-level after override removal, \`permission/3\` returning effective grant