### PR TITLE
Phase 4 (WAL): last_tick / range / tail + NDJSON-safe decoder

### DIFF
--- a/lib/arango/request.ex
+++ b/lib/arango/request.ex
@@ -175,6 +175,21 @@ defmodule Arango.Request do
     end)
   end
 
+  # On non-JSON 2xx responses the fallback depends on what the body
+  # actually carries:
+  #   - empty body (HEAD requests) → surface response headers so callers
+  #     like Document.header can read the etag.
+  #   - non-empty non-JSON body (NDJSON from Wal.tail, raw text without
+  #     Content-Type) → pass through unchanged.
+  defp decode_json_or_fallback(body, headers) do
+    {:ok, Jason.decode!(body)}
+  rescue
+    _ -> {:ok, fallback_body(body, headers)}
+  end
+
+  defp fallback_body(body, headers) when body in [nil, ""], do: decode_headers(headers)
+  defp fallback_body(body, _headers), do: body
+
   defp decode_headers(headers) do
     case List.keyfind(headers, "etag", 0) do
       {"etag", etag} ->
@@ -199,15 +214,7 @@ defmodule Arango.Request do
     case response do
       {:ok, %ApiConn.Response{status: status, headers: headers, body: body}}
       when status >= 200 and status < 300 ->
-        if text_content_type?(headers) do
-          {:ok, body}
-        else
-          try do
-            {:ok, Jason.decode!(body)}
-          rescue
-            _ -> {:ok, decode_headers(headers)}
-          end
-        end
+        if text_content_type?(headers), do: {:ok, body}, else: decode_json_or_fallback(body, headers)
 
       {:ok, %ApiConn.Response{status: status, headers: headers, body: body}} ->
         try do

--- a/lib/arango/wal.ex
+++ b/lib/arango/wal.ex
@@ -1,5 +1,5 @@
 defmodule Arango.Wal do
-  @moduledoc "ArangoDB Wal methods (3.12 surface — RocksDB)"
+  @moduledoc "ArangoDB WAL methods (3.12 surface — RocksDB)"
 
   use Arango.API, endpoint: :wal
 
@@ -17,6 +17,60 @@ defmodule Arango.Wal do
       system_only: true,
       path: "/_admin/wal/flush",
       body: flush_opts
+    )
+  end
+
+  @doc """
+  Return the current WAL tick.
+
+  GET /_api/wal/lastTick
+  """
+  @spec last_tick() :: Arango.Request.t()
+  def last_tick() do
+    request(method: :get, system_only: true, path: "/_api/wal/lastTick")
+  end
+
+  @doc """
+  Return the WAL tick range available (min and max).
+
+  GET /_api/wal/range
+  """
+  @spec range() :: Arango.Request.t()
+  def range() do
+    request(method: :get, system_only: true, path: "/_api/wal/range")
+  end
+
+  @doc """
+  Stream WAL operations from the requested tick onward.
+
+  GET /_api/wal/tail
+
+  Options: `:global`, `:from`, `:to`, `:lastScanned`, `:chunkSize`,
+  `:syncerId`, `:serverId`, `:clientInfo`.
+
+  The server returns NDJSON without a `Content-Type` header — the
+  driver passes the body through as a raw string. Split on `"\\n"` and
+  decode each line with `Jason.decode!/1` to consume.
+  """
+  @spec tail(keyword) :: Arango.Request.t()
+  def tail(opts \\ []) do
+    query =
+      Utils.opts_to_query(opts, [
+        :global,
+        :from,
+        :to,
+        :lastScanned,
+        :chunkSize,
+        :syncerId,
+        :serverId,
+        :clientInfo
+      ])
+
+    request(
+      method: :get,
+      system_only: true,
+      path: "/_api/wal/tail",
+      query: query
     )
   end
 end

--- a/test/arango/wal_test.exs
+++ b/test/arango/wal_test.exs
@@ -3,11 +3,35 @@ defmodule WalTest do
   doctest Arango
 
   alias Arango.Wal
+  alias Arango.Document
 
   test "flushes the WAL" do
     assert {:ok, %{}} = Wal.flush() |> arango()
     assert {:ok, %{}} = Wal.flush(waitForSync: true) |> arango()
     assert {:ok, %{}} = Wal.flush(waitForCollector: true) |> arango()
     assert {:ok, %{}} = Wal.flush(waitForSync: true, waitForCollector: true) |> arango()
+  end
+
+  test "last_tick/0 returns a numeric tick string" do
+    {:ok, %{"tick" => tick}} = Wal.last_tick() |> arango()
+    assert tick =~ ~r/^\d+$/
+  end
+
+  test "range/0 returns tickMin <= tickMax (numeric strings)" do
+    {:ok, %{"tickMin" => tick_min, "tickMax" => tick_max}} = Wal.range() |> arango()
+    assert tick_min =~ ~r/^\d+$/
+    assert tick_max =~ ~r/^\d+$/
+    assert String.to_integer(tick_min) <= String.to_integer(tick_max)
+  end
+
+  test "tail/1 returns NDJSON operations as a raw string", ctx do
+    {:ok, _} = Document.create(ctx.coll, %{"tail_test" => true}) |> on_db(ctx)
+    {:ok, _} = Wal.flush(waitForSync: true) |> arango()
+
+    {:ok, body} = Wal.tail(from: 0) |> arango()
+    assert is_binary(body)
+
+    ops = body |> String.split("\n", trim: true) |> Enum.map(&Jason.decode!/1)
+    assert Enum.any?(ops, &Map.has_key?(&1, "tick"))
   end
 end


### PR DESCRIPTION
## Summary

Ninth Phase 4 sub-PR per \`plans/04-update-existing.md\` (section 9). Adds the three 3.12 WAL endpoints + a small Request-layer change so the NDJSON body from \`tail\` comes through intact.

| Function | Method | Path |
|---|---|---|
| \`last_tick/0\` | GET | \`/_api/wal/lastTick\` |
| \`range/0\` | GET | \`/_api/wal/range\` |
| \`tail/1\` | GET | \`/_api/wal/tail\` |

**Plan correction:** the plan said \`flush/1\` 404s in 3.12. Verified via \`curl -i\`: PUT \`/_admin/wal/flush\` returns 200. Keeping \`flush/1\`. (The other plan deletions — \`properties\`/\`set_properties\`/\`transactions\` — landed in PR #18 and remain gone; \`transactions\` returns 501 Not Implemented.)

**Request-layer change for NDJSON.** \`tail\` returns newline-delimited JSON without a \`Content-Type\` header. The success branch was previously trying \`Jason.decode!\` and on failure returning the response headers — silently swallowing the body. New behavior:

| Response | Old | New |
|---|---|---|
| \`text/*\` content type | raw body (added in #11) | raw body (unchanged) |
| Valid JSON body | decoded | decoded |
| Empty body (HEAD) | headers map | **headers map (preserved)** |
| Non-empty non-JSON body | headers map *(silently swallowed body)* | **body raw** |

The HEAD-body-empty branch is preserved deliberately so \`Document.header\` keeps reading the etag out of the headers fallback. Non-empty non-JSON now comes through correctly — what makes \`tail\` work.

## Test plan

- [x] \`mix verify\` — format / compile-w-errors / credo / dialyzer all green
- [x] \`mix test\` — **257 / 0 / 0** (+3 WAL tests)
- [x] \`last_tick\` returns a numeric tick string
- [x] \`range\` returns \`tickMin\` ≤ \`tickMax\`
- [x] \`tail(from: 0)\` returns a binary that splits and decodes as NDJSON; at least one op contains a tick
- [x] Existing \`Document.header\` test still passes (HEAD body-empty fallback preserved)