### PR TITLE
Phase 5 (View): new Arango.View module — ArangoSearch + search-alias

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -31,5 +31,6 @@
   {"lib/arango/transaction.ex", :invalid_contract},
   {"lib/arango/user.ex", :invalid_contract},
   {"lib/arango/utils.ex", :invalid_contract},
+  {"lib/arango/view.ex", :invalid_contract},
   {"lib/arango/wal.ex", :invalid_contract}
 ]

--- a/lib/arango/config.ex
+++ b/lib/arango/config.ex
@@ -111,6 +111,7 @@ defmodule Arango.Config do
       task: %{},
       transaction: %{},
       user: %{},
+      view: %{},
       wal: %{}
     }
 

--- a/lib/arango/view.ex
+++ b/lib/arango/view.ex
@@ -1,0 +1,143 @@
+defmodule Arango.View do
+  @moduledoc """
+  ArangoDB Views — ArangoSearch (`type: "arangosearch"`) and search-alias
+  (`type: "search-alias"`).
+
+  ArangoSearch views are server-managed: link collections + analyzer
+  pipelines, the server builds and maintains the inverted indexes.
+  Search-alias views are a thin facade over pre-existing inverted
+  indexes (built with `Arango.Index.create_inverted/3`); the user owns
+  the indexes, the view is the queryable surface.
+
+  Note: `replace_properties/2` (PUT) is ArangoSearch-only; search-alias
+  views accept PATCH only.
+  """
+
+  use Arango.API, endpoint: :view
+
+  @doc """
+  List all views.
+
+  GET /_api/view
+  """
+  @spec views() :: Arango.Request.t()
+  def views() do
+    request(method: :get, path: "view")
+  end
+
+  @doc """
+  Return a view summary (id, name, type, globallyUniqueId).
+
+  GET /_api/view/{name}
+  """
+  @spec view(String.t()) :: Arango.Request.t()
+  def view(name) do
+    request(method: :get, path: "view/#{name}")
+  end
+
+  @doc """
+  Return the full properties block of a view.
+
+  GET /_api/view/{name}/properties
+  """
+  @spec properties(String.t()) :: Arango.Request.t()
+  def properties(name) do
+    request(method: :get, path: "view/#{name}/properties")
+  end
+
+  @doc """
+  Create an ArangoSearch view.
+
+  POST /_api/view
+
+  Whitelisted opts: `:links`, `:primarySort`, `:primarySortCompression`,
+  `:primarySortCache`, `:primaryKeyCache`, `:storedValues`,
+  `:consolidationIntervalMsec`, `:consolidationPolicy`,
+  `:commitIntervalMsec`, `:cleanupIntervalStep`, `:optimizeTopK`,
+  `:writebufferActive`, `:writebufferIdle`, `:writebufferSizeMax`.
+  Nested structures (`links`, `consolidationPolicy`) are passed as
+  raw maps.
+  """
+  @spec create_arangosearch(String.t(), keyword) :: Arango.Request.t()
+  def create_arangosearch(name, opts \\ []) do
+    body =
+      opts
+      |> Utils.opts_to_vars([
+        :links,
+        :primarySort,
+        :primarySortCompression,
+        :primarySortCache,
+        :primaryKeyCache,
+        :storedValues,
+        :consolidationIntervalMsec,
+        :consolidationPolicy,
+        :commitIntervalMsec,
+        :cleanupIntervalStep,
+        :optimizeTopK,
+        :writebufferActive,
+        :writebufferIdle,
+        :writebufferSizeMax
+      ])
+      |> Map.merge(%{"name" => name, "type" => "arangosearch"})
+
+    request(method: :post, path: "view", body: body)
+  end
+
+  @doc """
+  Create a search-alias view over pre-existing inverted indexes.
+
+  POST /_api/view
+
+  `indexes` is a list of `%{"collection" => name, "index" => id_or_name}`.
+  Build the underlying inverted indexes first with
+  `Arango.Index.create_inverted/3`.
+  """
+  @spec create_search_alias(String.t(), [map]) :: Arango.Request.t()
+  def create_search_alias(name, indexes) when is_list(indexes) do
+    body = %{"name" => name, "type" => "search-alias", "indexes" => indexes}
+    request(method: :post, path: "view", body: body)
+  end
+
+  @doc """
+  Drop a view.
+
+  DELETE /_api/view/{name}
+  """
+  @spec drop(String.t()) :: Arango.Request.t()
+  def drop(name) do
+    request(method: :delete, path: "view/#{name}")
+  end
+
+  @doc """
+  Patch a view's properties (works on both view types).
+
+  PATCH /_api/view/{name}/properties
+  """
+  @spec update_properties(String.t(), map) :: Arango.Request.t()
+  def update_properties(name, properties) do
+    request(method: :patch, path: "view/#{name}/properties", body: properties)
+  end
+
+  @doc """
+  Replace a view's properties (ArangoSearch only — search-alias accepts
+  PATCH only).
+
+  PUT /_api/view/{name}/properties
+  """
+  @spec replace_properties(String.t(), map) :: Arango.Request.t()
+  def replace_properties(name, properties) do
+    request(method: :put, path: "view/#{name}/properties", body: properties)
+  end
+
+  @doc """
+  Rename a view.
+
+  PUT /_api/view/{name}/rename
+
+  Single-server only — cluster deployments return 501.
+  """
+  @spec rename(String.t(), String.t()) :: Arango.Request.t()
+  def rename(name, new_name) do
+    request(method: :put, path: "view/#{name}/rename", body: %{name: new_name})
+  end
+end

--- a/lib/arango/view.ex
+++ b/lib/arango/view.ex
@@ -88,9 +88,13 @@ defmodule Arango.View do
 
   POST /_api/view
 
-  `indexes` is a list of `%{"collection" => name, "index" => id_or_name}`.
+  `indexes` is a list of `%{"collection" => name, "index" => index_name}`.
   Build the underlying inverted indexes first with
-  `Arango.Index.create_inverted/3`.
+  `Arango.Index.create_inverted/3` and pass them an explicit `name:` opt
+  so you can reference them here.
+
+  Note: the server resolves search-alias indexes by **name only** — passing
+  a full `collection/id` path returns `errorNum: 10 "Cannot find index"`.
   """
   @spec create_search_alias(String.t(), [map]) :: Arango.Request.t()
   def create_search_alias(name, indexes) when is_list(indexes) do

--- a/test/arango/view_test.exs
+++ b/test/arango/view_test.exs
@@ -1,0 +1,92 @@
+defmodule ViewTest do
+  use Arango.TestCase
+  doctest Arango
+
+  alias Arango.View
+  alias Arango.Index
+
+  test "views/0 returns an empty list on a fresh db", ctx do
+    assert {:ok, %{"result" => []}} = View.views() |> on_db(ctx)
+  end
+
+  test "create_arangosearch/2 with empty opts creates a view", ctx do
+    assert {:ok, %{"name" => "v1", "type" => "arangosearch", "id" => _}} =
+             View.create_arangosearch("v1") |> on_db(ctx)
+  end
+
+  test "create_arangosearch/2 with links links a collection", ctx do
+    {:ok, _} =
+      View.create_arangosearch("v_links",
+        links: %{ctx.coll.name => %{"includeAllFields" => true}}
+      )
+      |> on_db(ctx)
+
+    {:ok, props} = View.properties("v_links") |> on_db(ctx)
+    assert Map.has_key?(props["links"], ctx.coll.name)
+  end
+
+  test "create_search_alias/2 with indexes creates a search-alias view", ctx do
+    # search-alias references inverted indexes by NAME, not by full id.
+    {:ok, _} = Index.create_inverted(ctx.coll.name, ["foo"], name: "inv_for_alias") |> on_db(ctx)
+
+    assert {:ok, %{"type" => "search-alias", "name" => "v_alias"}} =
+             View.create_search_alias(
+               "v_alias",
+               [%{"collection" => ctx.coll.name, "index" => "inv_for_alias"}]
+             )
+             |> on_db(ctx)
+  end
+
+  test "view/1 returns the summary (no links/indexes block)", ctx do
+    {:ok, _} = View.create_arangosearch("v_sum") |> on_db(ctx)
+
+    assert {:ok, %{"name" => "v_sum", "type" => "arangosearch", "id" => _}} =
+             View.view("v_sum") |> on_db(ctx)
+  end
+
+  test "properties/1 returns the full properties block", ctx do
+    {:ok, _} = View.create_arangosearch("v_props") |> on_db(ctx)
+    {:ok, props} = View.properties("v_props") |> on_db(ctx)
+    assert is_integer(props["consolidationIntervalMsec"])
+    assert Map.has_key?(props, "links")
+  end
+
+  test "update_properties/2 patches an arangosearch view", ctx do
+    {:ok, _} = View.create_arangosearch("v_upd") |> on_db(ctx)
+    {:ok, _} = View.update_properties("v_upd", %{"commitIntervalMsec" => 2000}) |> on_db(ctx)
+
+    {:ok, props} = View.properties("v_upd") |> on_db(ctx)
+    assert props["commitIntervalMsec"] == 2000
+  end
+
+  test "replace_properties/2 replaces an arangosearch view", ctx do
+    {:ok, _} =
+      View.create_arangosearch("v_rep",
+        links: %{ctx.coll.name => %{"includeAllFields" => true}}
+      )
+      |> on_db(ctx)
+
+    {:ok, _} = View.replace_properties("v_rep", %{"links" => %{}}) |> on_db(ctx)
+
+    {:ok, props} = View.properties("v_rep") |> on_db(ctx)
+    assert props["links"] == %{}
+  end
+
+  test "rename/2 renames on single-server (or surfaces 501 on cluster)", ctx do
+    {:ok, _} = View.create_arangosearch("v_ren") |> on_db(ctx)
+
+    case View.rename("v_ren", "v_renamed") |> on_db(ctx) do
+      # Single-server: server returns the renamed view.
+      {:ok, %{"name" => "v_renamed"}} -> :ok
+      # Cluster: rename isn't implemented at this path.
+      {:error, %{"code" => 501}} -> :ok
+      other -> flunk("unexpected response: #{inspect(other)}")
+    end
+  end
+
+  test "drop/1 removes a view", ctx do
+    {:ok, _} = View.create_arangosearch("v_drop") |> on_db(ctx)
+    assert {:ok, %{"result" => true}} = View.drop("v_drop") |> on_db(ctx)
+    assert {:error, %{"code" => 404}} = View.view("v_drop") |> on_db(ctx)
+  end
+end


### PR DESCRIPTION
## Summary

First Phase 5 sub-PR per the recommended sequencing in \`plans/05-new-apis.md\` (View → Analyzer → Stream Tx 3.a → 3.b → Job → Auth → Token → Import). Adds the long-missing \`Arango.View\` namespace covering both view subtypes in one module per the agreed plan decision.

### New API

| Function | Method | Path | Notes |
|---|---|---|---|
| \`views/0\` | GET | \`/_api/view\` | list |
| \`view/1\` | GET | \`/_api/view/{name}\` | summary only |
| \`properties/1\` | GET | \`/_api/view/{name}/properties\` | full properties block |
| \`create_arangosearch/2\` | POST | \`/_api/view\` | server-managed; opts whitelist matches spec |
| \`create_search_alias/2\` | POST | \`/_api/view\` | facade over user-built inverted indexes |
| \`drop/1\` | DELETE | \`/_api/view/{name}\` |  |
| \`update_properties/2\` | PATCH | \`/_api/view/{name}/properties\` | both subtypes |
| \`replace_properties/2\` | PUT | \`/_api/view/{name}/properties\` | ArangoSearch only |
| \`rename/2\` | PUT | \`/_api/view/{name}/rename\` | single-server only |

\`create_arangosearch\` whitelists the full property surface from the 3.12 OpenAPI spec; nested structures (\`links\`, \`consolidationPolicy\`) pass through as raw maps. Pairs naturally with \`Index.create_inverted/3\` from Phase 4 — search-alias views are the queryable facade over the inverted indexes that PR added.

### Test details

10 tests, 0 skips (per the #18 rule). One probe finding worth noting: **search-alias views reference inverted indexes by name, not by full \`collection/id\` path** — confirmed via curl before writing the test. The test creates the inverted index with an explicit \`name:\` opt and references that name in the search-alias indexes list. The first-pass test used the full id and got \`errorNum: 10 "Cannot find index"\` — a real gotcha worth keeping in the test as documentation.

\`rename/2\` test uses the accept-either pattern from Phase 4: \`{:ok, %{"name" => new_name}}\` (single-server) OR \`{:error, %{"code" => 501}}\` (cluster).

## Test plan

- [x] \`mix verify\` — format / compile-w-errors / credo / dialyzer all green
- [x] \`mix test\` — **267 / 0 / 0** (+10 view tests, no skips)
- [x] \`Config.Defaults\` registers the \`:view\` endpoint
- [x] \`.dialyzer_ignore.exs\` extended with \`view.ex\` (same systemic spec mismatch as the other 14 modules)
- [ ] If you want the agreed Copilot review pass, drop a \`@copilot code review\` on the PR